### PR TITLE
Allow setting default request headers

### DIFF
--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -17,6 +17,11 @@ namespace Laserfiche.Repository.Api.Client
         string AccessToken { get; set; }
         string RefreshToken { get; set; }
 
+        /// <summary>
+        /// The headers which should be sent with each request.
+        /// </summary>
+        System.Net.Http.Headers.HttpRequestHeaders DefaultRequestHeaders { get; }
+
         Task<SwaggerResponse<Entry>> GetEntryAsync(string uriString, CancellationToken cancellationToken = default);
 
         /// <param name="callback">A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.</param>
@@ -213,6 +218,11 @@ namespace Laserfiche.Repository.Api.Client
     {
         public string AccessToken { get; set; }
         public string RefreshToken { get; set; }
+
+        public System.Net.Http.Headers.HttpRequestHeaders DefaultRequestHeaders
+        {
+            get { return _httpClient.DefaultRequestHeaders; }
+        }
 
         public async Task<SwaggerResponse<T>> ApiForEachAsync<T>(string nextLink, string prefer, Func<HttpRequestMessage, HttpClient, bool[], CancellationToken, Task<SwaggerResponse<T>>> sendAndProcessResponseAsync, CancellationToken cancellationToken) where T : new()
         {

--- a/tests/unit/Custom/LaserficheRepositoryApiClientCustomTest.cs
+++ b/tests/unit/Custom/LaserficheRepositoryApiClientCustomTest.cs
@@ -2,8 +2,11 @@
 using Moq.Protected;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -242,6 +245,84 @@ namespace Laserfiche.Repository.Api.Client.Test.Custom
                ItExpr.IsAny<CancellationToken>()
             );
         }
+        #endregion
+
+        #region SetDefaultHeaders
+
+        [Fact]
+        public async Task SetDefaultHeaders_DefaultHeadersInRequest()
+        {
+            // ARRANGE
+            string acceptLanguageHeaderValue = "fr-FR";
+            string baseAddress = "http://api.laserfiche.com/";
+            string repoId = "repoId";
+            Entry entry = new Entry()
+            {
+                Id = 10,
+                Name = "EntryName",
+                ParentId = 1,
+                FullPath = "/EntryName",
+                FolderPath = "/EntryName",
+                Creator = "Creator",
+                CreationTime = DateTimeOffset.Now,
+                LastModifiedTime = DateTimeOffset.Now,
+                EntryType = EntryType.Folder,
+                TemplateName = "Template",
+                TemplateId = 2,
+                VolumeName = "Volume"
+            };
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+               // Setup the PROTECTED method to mock
+               .Setup<Task<HttpResponseMessage>>(
+                  "SendAsync",
+                  ItExpr.IsAny<HttpRequestMessage>(),
+                  ItExpr.IsAny<CancellationToken>()
+               )
+               // prepare the expected response of the mocked http call
+               .ReturnsAsync(new HttpResponseMessage()
+               {
+                   StatusCode = HttpStatusCode.OK,
+                   Content = new StringContent(JsonConvert.SerializeObject(entry)),
+               })
+               .Verifiable();
+
+
+            // use real http client with mocked handler here
+            var httpClient = new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new Uri(baseAddress),
+            };
+
+            var client = new LaserficheRepositoryApiClient(httpClient);
+            client.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue(acceptLanguageHeaderValue));
+
+            // ACT
+            var swaggerResponse = await client.GetEntryAsync(repoId, entry.Id);
+            var result = swaggerResponse.Result;
+
+            // ASSERT
+            Assert.NotNull(result);
+            Assert.Equal(entry.Id, result.Id);
+            Assert.Equal(entry.Name, result.Name);
+
+            // also check the 'http' call was like we expected it
+            var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/Entries/{entry.Id}");
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+               Times.Exactly(1), // we expected a single external request
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Get  // we expected a GET request
+                  && req.RequestUri == expectedUri // to this uri
+                  && req.Headers.AcceptLanguage.ToString() == acceptLanguageHeaderValue
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Allow the option of setting default request headers. This can be useful for example if you want to send the Accept-Language header in every request