### PR TITLE
Issue/8 alternative nextlink apis

### DIFF
--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -321,7 +321,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
         /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns></returns>
-        Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
     }
 
     partial class LaserficheRepositoryApiClient : ILaserficheRepositoryApiClient
@@ -413,7 +413,7 @@ namespace Laserfiche.Repository.Api.Client
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTrusteeAttributeKeyValuePairsSendAsync, cancellationToken);
         }

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -42,7 +42,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, CancellationToken cancellationToken = default);
+        Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
  
 
         /// <param name="callback">A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.</param>

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -329,7 +329,7 @@ namespace Laserfiche.Repository.Api.Client
         public string AccessToken { get; set; }
         public string RefreshToken { get; set; }
 
-        public System.Net.Http.Headers.HttpRequestHeaders DefaultRequestHeaders
+        public HttpRequestHeaders DefaultRequestHeaders
         {
             get { return _httpClient.DefaultRequestHeaders; }
         }

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -213,7 +213,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
+        Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a collection of entries with odata.nextLink.
@@ -222,7 +222,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
         /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns></returns>
-        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a collection of field definitions. 
@@ -267,7 +267,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
         /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <returns></returns>
-        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Get a collection of tag definitions.
@@ -358,7 +358,7 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetEntryListingSendAsync, cancellationToken);
         }
@@ -383,7 +383,7 @@ namespace Laserfiche.Repository.Api.Client
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchContextHitsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchResultsSendAsync, cancellationToken);
         }
@@ -418,7 +418,7 @@ namespace Laserfiche.Repository.Api.Client
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTrusteeAttributeKeyValuePairsSendAsync, cancellationToken);
         }
 
-        public async Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
+        public async Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
             var response = await GetEntryListingAsync(repoId, entryId, groupByEntryType, fields, formatFields, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);
@@ -557,7 +557,7 @@ namespace Laserfiche.Repository.Api.Client
         }
 
 
-        public async Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, CancellationToken cancellationToken = default)
+        public async Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
 
         {
             // Initial request
@@ -588,8 +588,7 @@ namespace Laserfiche.Repository.Api.Client
 
             var paramDict = ValidateAndGetParamtersFromUri(templateUri, uri);
             string repoId = paramDict[repoIdKey];
-            int entryId = 0;
-            if (!Int32.TryParse(paramDict[entryIdKey], out entryId))
+            if (!int.TryParse(paramDict[entryIdKey], out int entryId))
             {
                 throw new ArgumentException($"Invalid value {paramDict[entryIdKey]} for entryId.");
             }

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -215,6 +215,28 @@ namespace Laserfiche.Repository.Api.Client
         Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
         Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+
+        Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
     }
 
     partial class LaserficheRepositoryApiClient : ILaserficheRepositoryApiClient
@@ -254,6 +276,61 @@ namespace Laserfiche.Repository.Api.Client
         public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetEntryListingSendAsync, cancellationToken);
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
 
         public async Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -214,28 +214,112 @@ namespace Laserfiche.Repository.Api.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of entries with odata.nextLink.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of field definitions. 
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of field values.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of WEntryLinkInfo.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of search context hits.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of search results.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of tag definitions.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of WTagInfo.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of template definitions.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of field TemplateFieldInfo.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of matching TemplateFieldInfo by template name.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
+        /// <summary>
+        /// Get a collection of trustee attributes.
+        /// </summary>
+        /// <param name="nextLink">Use nextlink returned from the backend to get the rest of the data.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns></returns>
         Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
     }
 

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -212,9 +212,9 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, CancellationToken cancellationToken = default);
-
+        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
     }
 
     partial class LaserficheRepositoryApiClient : ILaserficheRepositoryApiClient
@@ -251,9 +251,12 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        {
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetEntryListingSendAsync, cancellationToken);
+        }
 
-        public async Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataGetEntryChildren>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, CancellationToken cancellationToken = default)
-
+        public async Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
             var response = await GetEntryListingAsync(repoId, entryId, groupByEntryType, fields, formatFields, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -280,57 +280,57 @@ namespace Laserfiche.Repository.Api.Client
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldDefinitionsSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldValuesSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetLinkValuesFromEntrySendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchContextHitsSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchResultsSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagDefinitionsSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagsAssignedToEntrySendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateDefinitionsSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
         }
 
         public async Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTrusteeAttributeKeyValuePairsSendAsync, cancellationToken);
         }
 
         public async Task GetEntryListingForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using System.Net.Http;
 using System.Globalization;
+using System.Net.Http.Headers;
 
 [assembly: InternalsVisibleTo("Laserfiche.Repository.Api.Client.Test")]
 namespace Laserfiche.Repository.Api.Client
@@ -20,7 +21,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// The headers which should be sent with each request.
         /// </summary>
-        System.Net.Http.Headers.HttpRequestHeaders DefaultRequestHeaders { get; }
+        HttpRequestHeaders DefaultRequestHeaders { get; }
 
         Task<SwaggerResponse<Entry>> GetEntryAsync(string uriString, CancellationToken cancellationToken = default);
 

--- a/src/LaserficheRepositoryApiClientCustom.cs
+++ b/src/LaserficheRepositoryApiClientCustom.cs
@@ -214,27 +214,27 @@ namespace Laserfiche.Repository.Api.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task GetSearchResultsForEachAsync(Func<SwaggerResponse<ODataValueContextOfIListOfODataEntry>, bool> callback, string repoId, string searchToken, bool? groupByEntryType = null, bool? refresh = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
-        Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
+        Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
 
         Task<SwaggerResponse<ODataValueContextOfListOfAttribute>> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default);
     }
@@ -273,57 +273,57 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetEntryListingSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWFieldInfo>> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldDefinitionsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfFieldValue>> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldValuesSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWEntryLinkInfo>> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetLinkValuesFromEntrySendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfContextHit>> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchContextHitsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfODataEntry>> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchResultsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagDefinitionsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTagInfo>> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagsAssignedToEntrySendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfWTemplateInfo>> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateDefinitionsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
         }
 
-        public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize, CancellationToken cancellationToken = default)
+        public async Task<SwaggerResponse<ODataValueContextOfIListOfTemplateFieldInfo>> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             return await ApiForEachAsync(nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
         }

--- a/tests/integration/Attributes/GetAttributeKeysTest.cs
+++ b/tests/integration/Attributes/GetAttributeKeysTest.cs
@@ -28,7 +28,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
         }
 
         [TestMethod]
-        public async Task GetAttributes_Paging()
+        public async Task GetAttributes_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/integration/Attributes/GetAttributeKeysTest.cs
+++ b/tests/integration/Attributes/GetAttributeKeysTest.cs
@@ -49,5 +49,28 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
             await client.GetTrusteeAttributeKeyValuePairsForEachAsync(PagingCallback, TestConfig.RepositoryId, maxPageSize: maxPageSize);
         }
 
+        [TestMethod]
+        public async Task GetAttributes_SimplePaging()
+        {
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetTrusteeAttributeKeyValuePairsAsync(TestConfig.RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetTrusteeAttributeKeyValuePairsNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/Entries/GetEntryFieldsTest.cs
+++ b/tests/integration/Entries/GetEntryFieldsTest.cs
@@ -29,7 +29,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         }
 
         [TestMethod]
-        public async Task GetEntryFields_Paging()
+        public async Task GetEntryFields_ForEachPaging()
         {
             int entryId = 1;
             int maxPageSize = 10;

--- a/tests/integration/Entries/GetEntryFieldsTest.cs
+++ b/tests/integration/Entries/GetEntryFieldsTest.cs
@@ -50,5 +50,30 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
 
             await client.GetFieldValuesForEachAsync(PagingCallback, TestConfig.RepositoryId, entryId, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetEntryFields_SimplePaging()
+        {
+            int entryId = 1;
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetFieldValuesAsync(TestConfig.RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetFieldValuesNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/Entries/GetEntryLinksTest.cs
+++ b/tests/integration/Entries/GetEntryLinksTest.cs
@@ -29,7 +29,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         }
 
         [TestMethod]
-        public async Task GetEntryLinks_Paging()
+        public async Task GetEntryLinks_ForEachPaging()
         {
             int entryId = 1;
             int maxPageSize = 10;

--- a/tests/integration/Entries/GetEntryLinksTest.cs
+++ b/tests/integration/Entries/GetEntryLinksTest.cs
@@ -50,5 +50,30 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
 
             await client.GetLinkValuesFromEntryForEachAsync(PagingCallback, TestConfig.RepositoryId, entryId, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetEntryLinks_SimplePaging()
+        {
+            int entryId = 1;
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetLinkValuesFromEntryAsync(TestConfig.RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetLinkValuesFromEntryNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/Entries/GetEntryListingTest.cs
+++ b/tests/integration/Entries/GetEntryListingTest.cs
@@ -27,7 +27,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             var response = await client.GetEntryListingAsync(TestConfig.RepositoryId, entryId);
             var entries = response.Result?.Value;
             Assert.IsNotNull(entries);
-            foreach(var entry in entries)
+            foreach (var entry in entries)
             {
                 Assert.AreEqual(entryId, entry.ParentId);
             }
@@ -54,6 +54,26 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.GetEntryListingForEachAsync(PagingCallback, TestConfig.RepositoryId, entryId, maxPageSize: maxPageSize);
+        }
+
+        [TestMethod]
+        public async Task GetEntryListing_SimplePaging()
+        {
+            int entryId = 1;
+            int maxPageSize = 1;
+            
+            // Initial request
+            var response = await client.GetEntryListingAsync(TestConfig.RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+            
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetEntryListingNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
         }
     }
 }

--- a/tests/integration/Entries/GetEntryListingTest.cs
+++ b/tests/integration/Entries/GetEntryListingTest.cs
@@ -34,7 +34,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         }
 
         [TestMethod]
-        public async Task GetEntryListing_Paging()
+        public async Task GetEntryListing_ForEachPaging()
         {
             int entryId = 1;
             int maxPageSize = 10;

--- a/tests/integration/Entries/GetEntryListingTest.cs
+++ b/tests/integration/Entries/GetEntryListingTest.cs
@@ -65,7 +65,12 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             // Initial request
             var response = await client.GetEntryListingAsync(TestConfig.RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
             Assert.IsNotNull(response);
-            
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
             var nextLink = response.Result.OdataNextLink;
             Assert.IsNotNull(nextLink);
             Assert.IsTrue(response.Result.Value.Count <= maxPageSize);

--- a/tests/integration/Entries/GetEntryTagsTest.cs
+++ b/tests/integration/Entries/GetEntryTagsTest.cs
@@ -29,7 +29,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         }
 
         [TestMethod]
-        public async Task GetEntryTags_Paging()
+        public async Task GetEntryTags_ForEachPaging()
         {
             int entryId = 1;
             int maxPageSize = 10;

--- a/tests/integration/Entries/GetEntryTagsTest.cs
+++ b/tests/integration/Entries/GetEntryTagsTest.cs
@@ -50,5 +50,30 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
 
             await client.GetTagsAssignedToEntryForEachAsync(PagingCallback, TestConfig.RepositoryId, entryId, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetEntryTags_SimplePaging()
+        {
+            int entryId = 1;
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetTagsAssignedToEntryAsync(TestConfig.RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetTagsAssignedToEntryNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
+++ b/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
@@ -28,7 +28,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
         }
 
         [TestMethod]
-        public async Task GetFieldDefinitions_Paging()
+        public async Task GetFieldDefinitions_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
+++ b/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
@@ -48,5 +48,29 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
 
             await client.GetFieldDefinitionsForEachAsync(PagingCallback, TestConfig.RepositoryId, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetFieldDefinitions_SimplePaging()
+        {
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetFieldDefinitionsAsync(TestConfig.RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetFieldDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/Searches/GetSearchContextHitsTest.cs
+++ b/tests/integration/Searches/GetSearchContextHitsTest.cs
@@ -57,7 +57,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
         }
 
         [TestMethod]
-        public async Task GetSearchContextHits_Paging()
+        public async Task GetSearchContextHits_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/integration/Searches/GetSearchResultsTest.cs
+++ b/tests/integration/Searches/GetSearchResultsTest.cs
@@ -49,7 +49,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
         }
 
         [TestMethod]
-        public async Task GetSearchResults_Paging()
+        public async Task GetSearchResults_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
+++ b/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
@@ -48,5 +48,29 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
 
             await client.GetTagDefinitionsForEachAsync(PagingCallback, TestConfig.RepositoryId, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetTagDefinitions_SimplePaging()
+        {
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetTagDefinitionsAsync(TestConfig.RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetTagDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
+++ b/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
@@ -28,7 +28,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
         }
 
         [TestMethod]
-        public async Task GetTagDefinitions_Paging()
+        public async Task GetTagDefinitions_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
@@ -36,7 +36,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         }
 
         [TestMethod]
-        public async Task GetTemplateDefinitionFieldsByTemplateName_Paging()
+        public async Task GetTemplateDefinitionFieldsByTemplateName_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
@@ -60,5 +60,25 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
 
             await client.GetTemplateFieldDefinitionsByTemplateNameForEachAsync(PagingCallback, TestConfig.RepositoryId, firstTemplateDefinition.Name, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetTemplateDefinitionFieldsByTemplateName_SimplePaging()
+        {
+            int entryId = 1;
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetTemplateDefinitionsAsync(TestConfig.RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetTemplateDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
@@ -60,5 +60,29 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
 
             await client.GetTemplateFieldDefinitionsForEachAsync(PagingCallback, TestConfig.RepositoryId, firstTemplateDefinition.Id, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetTemplateDefinitionFields_SimplePaging()
+        {
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetTemplateDefinitionsAsync(TestConfig.RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetTemplateDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
@@ -36,7 +36,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         }
 
         [TestMethod]
-        public async Task GetTemplateDefinitionFields_Paging()
+        public async Task GetTemplateDefinitionFields_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
@@ -62,5 +62,29 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
 
             await client.GetTemplateDefinitionsForEachAsync(PagingCallback, TestConfig.RepositoryId, maxPageSize: maxPageSize);
         }
+
+        [TestMethod]
+        public async Task GetTemplateDefinition_SimplePaging()
+        {
+            int maxPageSize = 1;
+
+            // Initial request
+            var response = await client.GetTemplateDefinitionsAsync(TestConfig.RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(response);
+
+            if (response.Result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = response.Result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+
+            // Paging request
+            response = await client.GetTemplateDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.Result.Value.Count <= maxPageSize);
+        }
     }
 }

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
@@ -42,7 +42,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         }
 
         [TestMethod]
-        public async Task GetTemplateDefinition_Paging()
+        public async Task GetTemplateDefinition_ForEachPaging()
         {
             int maxPageSize = 10;
 

--- a/tests/unit/Entries/CreateCopyEntryTest.cs
+++ b/tests/unit/Entries/CreateCopyEntryTest.cs
@@ -20,7 +20,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             string repoId = "repoId";
             var request = new PostEntryChildrenRequest()
             {
-                EntryType = EntryType.Folder,
+                EntryType = PostEntryChildrenEntryType.Folder,
                 Name = "entry1"
             };
             var entry = new Entry()
@@ -114,7 +114,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var statusCode = HttpStatusCode.Unauthorized;
             var request = new PostEntryChildrenRequest()
             {
-                EntryType = EntryType.Folder,
+                EntryType = PostEntryChildrenEntryType.Folder,
                 Name = "entry1"
             };
 
@@ -174,7 +174,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             string repoId = "repoId";
             var request = new PostEntryChildrenRequest()
             {
-                EntryType = EntryType.Folder,
+                EntryType = PostEntryChildrenEntryType.Folder,
                 Name = "entry1"
             };
             var entry = new Entry()

--- a/tests/unit/Entries/GetEntryListingTest.cs
+++ b/tests/unit/Entries/GetEntryListingTest.cs
@@ -21,11 +21,11 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             int entryId = 1;
-            ODataValueOfIListOfODataEntry entries = new ODataValueOfIListOfODataEntry()
+            ODataValueContextOfIListOfODataGetEntryChildren entries = new ODataValueContextOfIListOfODataGetEntryChildren()
             {
-                Value = new List<ODataEntry>()
+                Value = new List<ODataGetEntryChildren>()
                 {
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 101,
                         Name = "entry2",
@@ -195,11 +195,11 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             bool countQueryParameter = true;
             bool formatFields = true;
             string culture = "fr";
-            ODataValueOfIListOfODataEntry entries = new ODataValueOfIListOfODataEntry()
+            ODataValueOfIListOfODataGetEntryChildren entries = new ODataValueOfIListOfODataGetEntryChildren()
             {
-                Value = new List<ODataEntry>()
+                Value = new List<ODataGetEntryChildren>()
                 {
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 100,
                         Name = "entry1",

--- a/tests/unit/Searches/GetSearchResultsTest.cs
+++ b/tests/unit/Searches/GetSearchResultsTest.cs
@@ -21,11 +21,11 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             string searchToken = "123-ABC";
-            ODataValueOfIListOfODataEntry entries = new ODataValueOfIListOfODataEntry()
+            ODataValueContextOfIListOfODataGetEntryChildren entries = new ODataValueContextOfIListOfODataGetEntryChildren()
             {
-                Value = new List<ODataEntry>()
+                Value = new List<ODataGetEntryChildren>()
                 {
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 101,
                         Name = "entry2",
@@ -196,11 +196,11 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             bool countQueryParameter = true;
             bool formatFields = true;
             string culture = "fr";
-            ODataValueOfIListOfODataEntry entries = new ODataValueOfIListOfODataEntry()
+            ODataValueContextOfIListOfODataGetEntryChildren entries = new ODataValueContextOfIListOfODataGetEntryChildren()
             {
-                Value = new List<ODataEntry>()
+                Value = new List<ODataGetEntryChildren>()
                 {
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 100,
                         Name = "entry1",

--- a/tests/unit/SimpleSearches/SimpleSearchTest.cs
+++ b/tests/unit/SimpleSearches/SimpleSearchTest.cs
@@ -20,11 +20,11 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             var request = new SimpleSearchRequest() { SearchCommand = "({LF:Basic ~= \"search text\", option=\"DFANLT\"})" };
-            ODataValueOfIListOfODataEntry entries = new ODataValueOfIListOfODataEntry()
+            ODataValueOfIListOfODataGetEntryChildren entries = new ODataValueOfIListOfODataGetEntryChildren()
             {
-                Value = new List<ODataEntry>()
+                Value = new List<ODataGetEntryChildren>()
                 {
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -40,7 +40,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 101,
                         Name = "entry2",
@@ -136,11 +136,11 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             var request = new SimpleSearchRequest() { SearchCommand = "({LF:Basic ~= \"search text\", option=\"DFANLT\"})" };
-            ODataValueOfIListOfODataEntry entries = new ODataValueOfIListOfODataEntry()
+            ODataValueOfIListOfODataGetEntryChildren entries = new ODataValueOfIListOfODataGetEntryChildren()
             {
-                Value = new List<ODataEntry>()
+                Value = new List<ODataGetEntryChildren>()
                 {
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -156,7 +156,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new ODataEntry()
+                    new ODataGetEntryChildren()
                     {
                         Id = 101,
                         Name = "entry2",


### PR DESCRIPTION
We currently have the callback style API for retrieving data using odata.nextlink. In this PR, we add a set of counterparts that don't require passing in a callback.

Fix #8 