### PR TITLE
Fix log message for integration test when env is not found

### DIFF
--- a/tests/integration/Attributes/GetAttributeKeysTest.cs
+++ b/tests/integration/Attributes/GetAttributeKeysTest.cs
@@ -41,7 +41,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
             }
 
             await client.AttributesClient.GetTrusteeAttributeKeyValuePairsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Attributes/GetAttributeKeysTest.cs
+++ b/tests/integration/Attributes/GetAttributeKeysTest.cs
@@ -41,6 +41,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
             }
 
             await client.AttributesClient.GetTrusteeAttributeKeyValuePairsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -23,9 +23,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
 
         private void TryLoadFromDotEnv(string fileName)
         {
-            try
+            var path = Path.Combine(Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName, fileName);
+            if (File.Exists(path))
             {
-                var path = Path.Combine(Directory.GetParent(Environment.CurrentDirectory).Parent.Parent.FullName, fileName);
                 DotNetEnv.Env.Load(path, new DotNetEnv.LoadOptions(
                     setEnvVars: true,
                     clobberExistingVars: true,
@@ -33,7 +33,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
                 ));
                 System.Diagnostics.Trace.TraceWarning($"{fileName} found. {fileName} file should only be used in local developer computers.");
             }
-            catch
+            else
             {
                 System.Diagnostics.Trace.WriteLine($"{fileName} not found.");
             }

--- a/tests/integration/Entries/CopyEntryAsyncTest.cs
+++ b/tests/integration/Entries/CopyEntryAsyncTest.cs
@@ -29,7 +29,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 {
                     DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                     await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
-                    Thread.Sleep(5000);
                 }
             }
         }

--- a/tests/integration/Entries/CopyEntryAsyncTest.cs
+++ b/tests/integration/Entries/CopyEntryAsyncTest.cs
@@ -38,7 +38,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         {
             // Create a new folder that contains the created entry
             var testFolderName = "CreateCopyEntry_CopyEntry_test_folder";
-            var testFolder = CreateEntry(client, testFolderName);
+            var testFolder = await CreateEntry(client, testFolderName);
+            createdEntries.Add(testFolder);
 
             // Create new entry
             string newEntryName = "APIServerClientIntegrationTest CreateFolder";
@@ -49,7 +50,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             };
             var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, testFolder.Id, request, autoRename: true);
             Assert.IsNotNull(targetEntry);
-            createdEntries.Add(targetEntry);
             Assert.AreEqual(testFolder.Id, targetEntry.ParentId);
             Assert.AreEqual(EntryType.Folder, targetEntry.EntryType);
 
@@ -66,10 +66,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             await Task.Delay(5000);
             var opResponse = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, opToken);
             Assert.AreEqual(OperationStatus.Completed, opResponse.Status);
-
-            // Remove the folder that contains the created entry
-            var deletionResult = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, testFolder.Id, new DeleteEntryWithAuditReason());
-            Assert.IsTrue(!string.IsNullOrEmpty(deletionResult.Token));
         }
     }
 }

--- a/tests/integration/Entries/CreateCopyEntryTest.cs
+++ b/tests/integration/Entries/CreateCopyEntryTest.cs
@@ -28,7 +28,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 {
                     DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                     await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
-                    Thread.Sleep(5000);
                 }
             }
         }

--- a/tests/integration/Entries/GetEdocContentTypeTest.cs
+++ b/tests/integration/Entries/GetEdocContentTypeTest.cs
@@ -27,7 +27,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                 await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
-                Thread.Sleep(10000);
             }
         }
 

--- a/tests/integration/Entries/GetEdocTest.cs
+++ b/tests/integration/Entries/GetEdocTest.cs
@@ -31,7 +31,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                 await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
-                Thread.Sleep(10000);
             }
         }
 

--- a/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
+++ b/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
@@ -31,7 +31,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                 await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
-                Thread.Sleep(10000);
             }
         }
 

--- a/tests/integration/Entries/GetEntryFieldsTest.cs
+++ b/tests/integration/Entries/GetEntryFieldsTest.cs
@@ -43,7 +43,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetFieldValuesForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryFieldsTest.cs
+++ b/tests/integration/Entries/GetEntryFieldsTest.cs
@@ -43,6 +43,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetFieldValuesForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryLinksTest.cs
+++ b/tests/integration/Entries/GetEntryLinksTest.cs
@@ -43,6 +43,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetLinkValuesFromEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryLinksTest.cs
+++ b/tests/integration/Entries/GetEntryLinksTest.cs
@@ -43,7 +43,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetLinkValuesFromEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryListingTest.cs
+++ b/tests/integration/Entries/GetEntryListingTest.cs
@@ -48,7 +48,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetEntryListingForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryListingTest.cs
+++ b/tests/integration/Entries/GetEntryListingTest.cs
@@ -48,6 +48,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetEntryListingForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryTagsTest.cs
+++ b/tests/integration/Entries/GetEntryTagsTest.cs
@@ -43,6 +43,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetTagsAssignedToEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryTagsTest.cs
+++ b/tests/integration/Entries/GetEntryTagsTest.cs
@@ -43,7 +43,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
 
             await client.EntriesClient.GetTagsAssignedToEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Entries/GetEntryTest.cs
+++ b/tests/integration/Entries/GetEntryTest.cs
@@ -25,7 +25,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                 await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
-                Thread.Sleep(10000);
             }
         }
 

--- a/tests/integration/Entries/ImportDocumentTest.cs
+++ b/tests/integration/Entries/ImportDocumentTest.cs
@@ -29,7 +29,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                 await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
-                Thread.Sleep(5000);
             }
         }
 

--- a/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
+++ b/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
@@ -41,7 +41,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
             }
 
             await client.FieldDefinitionsClient.GetFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
+++ b/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
@@ -41,6 +41,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
             }
 
             await client.FieldDefinitionsClient.GetFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Searches/GetSearchContextHitsTest.cs
+++ b/tests/integration/Searches/GetSearchContextHitsTest.cs
@@ -92,6 +92,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             }
 
             await client.SearchesClient.GetSearchContextHitsForEachAsync(PagingCallback, RepositoryId, token, rowNumber, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
     }
 }

--- a/tests/integration/Searches/GetSearchContextHitsTest.cs
+++ b/tests/integration/Searches/GetSearchContextHitsTest.cs
@@ -39,7 +39,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            Thread.Sleep(5000);
+            await Task.Delay(5000);
 
             // Get search results
             var searchResultsResponse = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token);
@@ -68,7 +68,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            Thread.Sleep(5000);
+            await Task.Delay(5000);
 
             // Get search results
             var searchResultsResponse = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token);

--- a/tests/integration/Searches/GetSearchContextHitsTest.cs
+++ b/tests/integration/Searches/GetSearchContextHitsTest.cs
@@ -92,7 +92,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             }
 
             await client.SearchesClient.GetSearchContextHitsForEachAsync(PagingCallback, RepositoryId, token, rowNumber, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
     }
 }

--- a/tests/integration/Searches/GetSearchResultsTest.cs
+++ b/tests/integration/Searches/GetSearchResultsTest.cs
@@ -77,7 +77,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             }
 
             await client.SearchesClient.GetSearchResultsForEachAsync(PagingCallback, RepositoryId, token, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Searches/GetSearchResultsTest.cs
+++ b/tests/integration/Searches/GetSearchResultsTest.cs
@@ -77,6 +77,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             }
 
             await client.SearchesClient.GetSearchResultsForEachAsync(PagingCallback, RepositoryId, token, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Searches/GetSearchResultsTest.cs
+++ b/tests/integration/Searches/GetSearchResultsTest.cs
@@ -38,7 +38,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             token = searchResult.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            Thread.Sleep(10000);
+            await Task.Delay(10000);
 
             // Get search results
             var searchResultsResult = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token);
@@ -60,7 +60,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            Thread.Sleep(10000);
+            await Task.Delay(10000);
 
             Task<bool> PagingCallback(ODataValueContextOfIListOfEntry data)
             {
@@ -94,7 +94,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            Thread.Sleep(10000);
+            await Task.Delay(10000);
 
             // Initial request
             var result = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token, prefer: $"maxpagesize={maxPageSize}");

--- a/tests/integration/Searches/GetSearchStatusTest.cs
+++ b/tests/integration/Searches/GetSearchStatusTest.cs
@@ -38,7 +38,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            Thread.Sleep(5000);
+            await Task.Delay(5000);
 
             // Get search status
             var searchStatus = await client.SearchesClient.GetSearchStatusAsync(RepositoryId, token);

--- a/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
+++ b/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
@@ -41,6 +41,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
             }
 
             await client.TagDefinitionsClient.GetTagDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
+++ b/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
@@ -41,7 +41,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
             }
 
             await client.TagDefinitionsClient.GetTagDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/Tasks/CancelOpeartionTest.cs
+++ b/tests/integration/Tasks/CancelOpeartionTest.cs
@@ -26,7 +26,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
 
             try
             {
-                Thread.Sleep(5000);
+                await Task.Delay(5000);
                 await client.TasksClient.CancelOperationAsync(RepositoryId, token);
                 Assert.Fail("Long operation should have ended before cancel.");
             }

--- a/tests/integration/Tasks/GetOperationStatusTest.cs
+++ b/tests/integration/Tasks/GetOperationStatusTest.cs
@@ -25,7 +25,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
             var token = result.Token;
             Assert.IsFalse(string.IsNullOrEmpty(token));
 
-            Thread.Sleep(5000);
+            await Task.Delay(5000);
 
             var operationProgress = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, token);
             Assert.IsNotNull(operationProgress);

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
@@ -53,6 +53,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             }
 
             await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Name, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
@@ -53,7 +53,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             }
 
             await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Name, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
@@ -53,6 +53,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             }
 
             await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Id, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
@@ -53,7 +53,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             }
 
             await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Id, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
@@ -55,7 +55,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             }
 
             await client.TemplateDefinitionsClient.GetTemplateDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
         }
 
         [TestMethod]

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
@@ -55,6 +55,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             }
 
             await client.TemplateDefinitionsClient.GetTemplateDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
         }
 
         [TestMethod]


### PR DESCRIPTION
Correct log message shown now when env is missing. I also added a 5 sec delay at the end of each of the nextlink paging integration tests to avoid rate limit issues and removed some unneeded delays at the end of tests

![image](https://user-images.githubusercontent.com/102689343/171261576-e926b0c3-ec75-45f6-8265-b65bca692212.png)
