### PR TITLE
Access key in env file is now encoded using base64

### DIFF
--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -3,6 +3,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace Laserfiche.Repository.Api.Client.IntegrationTest
@@ -14,6 +15,10 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
         protected AccessKey AccessKey;
         protected string ServicePrincipalKey;
         protected string RepositoryId;
+
+        private const string AccessKeyVar = "DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY";
+        private const string SpKeyVar = "DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY";
+        private const string RepoKeyVar = "DEV_CA_PUBLIC_USE_REPOSITORY_ID_1";
 
         public BaseTest()
         {
@@ -31,19 +36,26 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
                     clobberExistingVars: true,
                     onlyExactPath: true
                 ));
+
                 System.Diagnostics.Trace.TraceWarning($"{fileName} found. {fileName} file should only be used in local developer computers.");
             }
             else
-            {
                 System.Diagnostics.Trace.WriteLine($"{fileName} not found.");
-            }
+        }
+
+        private static string DecodeBase64(string encoded)
+        {
+            return Encoding.UTF8.GetString(Convert.FromBase64String(encoded));
         }
 
         private void PopulateFromEnv()
         {
-            ServicePrincipalKey = Environment.GetEnvironmentVariable("DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY");
-            AccessKey = JsonConvert.DeserializeObject<AccessKey>(Environment.GetEnvironmentVariable("DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY"));
-            RepositoryId = Environment.GetEnvironmentVariable("DEV_CA_PUBLIC_USE_REPOSITORY_ID_1");
+            ServicePrincipalKey = Environment.GetEnvironmentVariable(SpKeyVar);
+
+            var accessKeyStr = DecodeBase64(Environment.GetEnvironmentVariable(AccessKeyVar));
+            AccessKey = JsonConvert.DeserializeObject<AccessKey>(accessKeyStr);
+
+            RepositoryId = Environment.GetEnvironmentVariable(RepoKeyVar);
         }
 
         public IRepositoryApiClient CreateClient()


### PR DESCRIPTION
Fix #29
For details, see linked issue.