### PR TITLE
Rename created files during integration tests

### DIFF
--- a/tests/integration/Entries/CopyEntryAsyncTest.cs
+++ b/tests/integration/Entries/CopyEntryAsyncTest.cs
@@ -34,12 +34,12 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task CreateCopyEntry_CopyEntry()
         {
             // Create a new folder that contains the created entry
-            var testFolderName = "CreateCopyEntry_CopyEntry_test_folder";
+            var testFolderName = "RepositoryApiClientIntegrationTest .Net CreateCopyEntry_CopyEntry_test_folder";
             var testFolder = await CreateEntry(client, testFolderName);
             createdEntries.Add(testFolder);
 
             // Create new entry
-            string newEntryName = "APIServerClientIntegrationTest CreateFolder";
+            string newEntryName = "RepositoryApiClientIntegrationTest .Net CreateFolder";
             var request = new PostEntryChildrenRequest()
             {
                 EntryType = PostEntryChildrenEntryType.Folder,
@@ -53,7 +53,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             // Copy entry
             var copyRequest = new CopyAsyncRequest()
             {
-                Name = "CopiedEntry",
+                Name = "RepositoryApiClientIntegrationTest .Net CopiedEntry",
                 SourceId = targetEntry.Id
             };
             var copyResult = await client.EntriesClient.CopyEntryAsync(RepositoryId, testFolder.Id, copyRequest, autoRename: true);

--- a/tests/integration/Entries/CreateCopyEntryTest.cs
+++ b/tests/integration/Entries/CreateCopyEntryTest.cs
@@ -33,7 +33,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task CreateCopyEntry_CreateFolder()
         {
-            string newEntryName = "APIServerClientIntegrationTest CreateFolder";
+            string newEntryName = "RepositoryApiClientIntegrationTest .Net CreateFolder";
             int parentEntryId = 1;
             var request = new PostEntryChildrenRequest()
             {
@@ -53,7 +53,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task CreateCopyEntry_CreateShortcut()
         {
             // Create new entry
-            string newEntryName = "APIServerClientIntegrationTest CreateFolder";
+            string newEntryName = "RepositoryApiClientIntegrationTest .Net CreateFolder";
             int parentEntryId = 1;
             var request = new PostEntryChildrenRequest()
             {
@@ -67,7 +67,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.AreEqual(EntryType.Folder, targetEntry.EntryType);
 
             // Create shortcut to the new entry
-            newEntryName = "APIServerClientIntegrationTest CreateShortcut";
+            newEntryName = "RepositoryApiClientIntegrationTest .Net CreateShortcut";
             request = new PostEntryChildrenRequest()
             {
                 EntryType = PostEntryChildrenEntryType.Shortcut,
@@ -89,7 +89,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task CreateCopyEntry_CopyShortcut()
         {
             // Create new entry
-            string newEntryName = "APIServerClientIntegrationTest CreateFolder";
+            string newEntryName = "RepositoryApiClientIntegrationTest .Net CreateFolder";
             int parentEntryId = 1;
             var request = new PostEntryChildrenRequest()
             {
@@ -103,7 +103,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.AreEqual(EntryType.Folder, targetEntry.EntryType);
             
             // Create shortcut to the new entry
-            newEntryName = "APIServerClientIntegrationTest CreateShortcut";
+            newEntryName = "RepositoryApiClientIntegrationTest .Net CreateShortcut";
             request = new PostEntryChildrenRequest()
             {
                 EntryType = PostEntryChildrenEntryType.Shortcut,
@@ -120,7 +120,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             // Copy entry
             request = new PostEntryChildrenRequest()
             {
-                Name = "CopiedEntry",
+                Name = "RepositoryApiClientIntegrationTest .Net CopiedEntry",
                 SourceId = shortcut.Id
             };
             var newEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
@@ -137,7 +137,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task CreateCopyEntry_CopyFolder()
         {
             // Create new entry
-            string newEntryName = "APIServerClientIntegrationTest CreateFolder";
+            string newEntryName = "RepositoryApiClientIntegrationTest .Net CreateFolder";
             int parentEntryId = 1;
             var request = new PostEntryChildrenRequest()
             {
@@ -153,7 +153,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             // Copy entry
             request = new PostEntryChildrenRequest()
             {
-                Name = "CopiedEntry",
+                Name = "RepositoryApiClientIntegrationTest .Net CopiedEntry",
                 SourceId = targetEntry.Id
             };
             _ = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);

--- a/tests/integration/Entries/DeleteEntryTest.cs
+++ b/tests/integration/Entries/DeleteEntryTest.cs
@@ -17,7 +17,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task DeleteEntry_ReturnOperationToken()
         {
-            var deleteEntry = await CreateEntry(client, "APIServerClientIntegrationTest DeleteFolder");
+            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net DeleteFolder");
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
             var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body);
             var token = result.Token;

--- a/tests/integration/Entries/GetEdocTest.cs
+++ b/tests/integration/Entries/GetEdocTest.cs
@@ -36,7 +36,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         private async Task<int> CreateDocument()
         {
             int parentEntryId = 1;
-            string fileName = "APIServerClientIntegrationTest GetDocumentContent";
+            string fileName = "RepositoryApiClientIntegrationTest .Net GetDocumentContent";
             string fileLocation = TempPath + "test.pdf";
             var request = new PostEntryWithEdocMetadataRequest();
             using (var fileStream = File.OpenRead(fileLocation))

--- a/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
+++ b/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
@@ -36,7 +36,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         private async Task<int> CreateDocument()
         {
             int parentEntryId = 1;
-            string fileName = "APIServerClientIntegrationTest GetDocumentContent AuditReason";
+            string fileName = "RepositoryApiClientIntegrationTest .Net GetDocumentContent AuditReason";
             string fileLocation = TempPath + "test.pdf";
             var request = new PostEntryWithEdocMetadataRequest();
             using (var fileStream = File.OpenRead(fileLocation))

--- a/tests/integration/Entries/GetEntryTest.cs
+++ b/tests/integration/Entries/GetEntryTest.cs
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         private async Task<int> CreateDocument()
         {
             int parentEntryId = 1;
-            string fileName = "APIServerClientIntegrationTest GetEntry";
+            string fileName = "RepositoryApiClientIntegrationTest .Net GetEntry";
             string fileLocation = TempPath + "test.pdf";
             var request = new PostEntryWithEdocMetadataRequest();
             using (var fileStream = File.OpenRead(fileLocation))

--- a/tests/integration/Entries/ImportDocumentTest.cs
+++ b/tests/integration/Entries/ImportDocumentTest.cs
@@ -42,7 +42,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task ImportDocument_DocumentCreated()
         {
             int parentEntryId = 1;
-            string fileName = "APIServerClientIntegrationTest ImportDocument";
+            string fileName = "RepositoryApiClientIntegrationTest .Net ImportDocument";
             var electronicDocument = GetFileParameter();
             var request = new PostEntryWithEdocMetadataRequest();
 
@@ -78,7 +78,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.IsNotNull(template, "Could not find a good template definition to assign to the entry");
 
             int parentEntryId = 1;
-            string fileName = "APIServerClientIntegrationTest ImportDocument";
+            string fileName = "RepositoryApiClientIntegrationTest .Net ImportDocument";
             var electronicDocument = GetFileParameter();
             var request = new PostEntryWithEdocMetadataRequest()
             {

--- a/tests/integration/Entries/MoveEntryTest.cs
+++ b/tests/integration/Entries/MoveEntryTest.cs
@@ -33,14 +33,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task MoveAndRenameEntry_ReturnEntry()
         {
-            var parentFolder = await CreateEntry(client, "APIServerClientIntegrationTest ParentFolder");
+            var parentFolder = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ParentFolder");
             createdEntries.Add(parentFolder);
-            var childFolder = await CreateEntry(client, "APIServerClientIntegrationTest ChildFolder");
+            var childFolder = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ChildFolder");
             createdEntries.Add(childFolder);
             var request = new PatchEntryRequest()
             {
                 ParentId = parentFolder.Id,
-                Name = "APIServerClientIntegrationTest MovedFolder"
+                Name = "RepositoryApiClientIntegrationTest .Net MovedFolder"
             };
 
             var movedEntry = await client.EntriesClient.MoveOrRenameDocumentAsync(RepositoryId, childFolder.Id, request, autoRename: true);

--- a/tests/integration/Entries/RemoveTemplateFromEntryTest.cs
+++ b/tests/integration/Entries/RemoveTemplateFromEntryTest.cs
@@ -52,7 +52,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 TemplateName = template.Name
             };
-            entry = await CreateEntry(client, "APIServerClientIntegrationTest RemoveTemplateFromEntry");
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net RemoveTemplateFromEntry");
             var setTemplateEntryResult = await client.EntriesClient.WriteTemplateValueToEntryAsync(RepositoryId, entry.Id, request);
             Assert.IsNotNull(setTemplateEntryResult);
             Assert.AreEqual(template.Name, setTemplateEntryResult.TemplateName);

--- a/tests/integration/Entries/SetFieldsTest.cs
+++ b/tests/integration/Entries/SetFieldsTest.cs
@@ -57,7 +57,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                     }
                 }
             };
-            entry = await CreateEntry(client, "APIServerClientIntegrationTest SetFields");
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetFields");
 
             var result = await client.EntriesClient.AssignFieldValuesAsync(RepositoryId, entry.Id, requestBody);
             var fields = result.Value;

--- a/tests/integration/Entries/SetLinksTest.cs
+++ b/tests/integration/Entries/SetLinksTest.cs
@@ -34,9 +34,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task SetLinks_ReturnLinks()
         {
-            var sourceEntry = await CreateEntry(client, "APIServerClientIntegrationTest SetLinks Source");
+            var sourceEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetLinks Source");
             createdEntries.Add(sourceEntry);
-            var targetEntry = await CreateEntry(client, "APIServerClientIntegrationTest SetLinks Target");
+            var targetEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetLinks Target");
             createdEntries.Add(targetEntry);
             var request = new List<PutLinksRequest>()
             {

--- a/tests/integration/Entries/SetTagsTest.cs
+++ b/tests/integration/Entries/SetTagsTest.cs
@@ -40,7 +40,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 Tags = new List<string>() { tag }
             };
-            entry = await CreateEntry(client, "APIServerClientIntegrationTest SetTags");
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetTags");
 
             var result = await client.EntriesClient.AssignTagsAsync(RepositoryId, entry.Id, request);
             var tags = result.Value;

--- a/tests/integration/Entries/SetTemplateTest.cs
+++ b/tests/integration/Entries/SetTemplateTest.cs
@@ -52,7 +52,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 TemplateName = template.Name
             };
-            entry = await CreateEntry(client, "APIServerClientIntegrationTest DeleteTemplate");
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net DeleteTemplate");
             var setTemplateResult = await client.EntriesClient.WriteTemplateValueToEntryAsync(RepositoryId, entry.Id, request);
             Assert.IsNotNull(setTemplateResult);
             Assert.AreEqual(template.Name, setTemplateResult.TemplateName);

--- a/tests/integration/Tasks/CancelOperationTest.cs
+++ b/tests/integration/Tasks/CancelOperationTest.cs
@@ -17,7 +17,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
         [TestMethod]
         public async Task CancelOpeartion_OperationEndedBeforeCancel()
         {
-            var deleteEntry = await CreateEntry(client, "APIServerClientIntegrationTest CancelOperation");
+            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net CancelOperation");
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
             var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body);
             var token = result.Token;

--- a/tests/integration/Tasks/GetOperationStatusTest.cs
+++ b/tests/integration/Tasks/GetOperationStatusTest.cs
@@ -17,7 +17,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
         [TestMethod]
         public async Task GetOperationStatus_ReturnStatus()
         {
-            var deleteEntry = await CreateEntry(client, "APIServerClientIntegrationTest GetOperationStatus");
+            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net GetOperationStatus");
 
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
             var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body);


### PR DESCRIPTION
Rename `APIServerClientIntegrationTest` prefix to `RepositoryApiClientIntegrationTest .Net` to distinguish between test files created from this library and other libraries in case they are not deleted