### PR TITLE
Add LinkDefinition APIs and other minor changes for 1.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: "1.0.1"
+  VERSION_PREFIX: "1.0.2"
 
 jobs:
   build-n-test:
@@ -94,6 +94,7 @@ jobs:
 
   publish-documentation:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: documentation
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
@@ -123,6 +124,7 @@ jobs:
 
   publish-preview-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
@@ -159,6 +161,7 @@ jobs:
 
   publish-production-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: production
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish

--- a/src/Clients/LinkDefinitionsClient.cs
+++ b/src/Clients/LinkDefinitionsClient.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client
+{
+    /// <summary>
+    /// The Laserfiche Repository Link Definitions API client.
+    /// </summary>
+    partial interface ILinkDefinitionsClient
+    {
+        /// <summary>
+        /// Returns a collection of link definitions using paging. Page results are returned to the <paramref name="callback"/>.
+        /// </summary>
+        /// <param name="callback">A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <param name="repoId">The requested repository ID.</param>
+        /// <param name="prefer">An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.</param>
+        /// <param name="select">Limits the properties returned in the result.</param>
+        /// <param name="orderby">Specifies the order in which items are returned. The maximum number of expressions is 5.</param>
+        /// <param name="top">Limits the number of items returned from a collection.</param>
+        /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
+        /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task GetLinkDefinitionsForEachAsync(Func<ODataValueContextOfIListOfEntryLinkTypeInfo, Task<bool>> callback, string repoId, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns a collection of link definitions using a nextlink. 
+        /// </summary>
+        /// <param name="nextLink">A url that allows retrieving the next subset of the requested collection.</param>
+        /// <param name="maxPageSize">Optionally specify the maximum number of items to retrieve.</param>
+        /// <param name="cancellationToken">Optional cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Get link definitions successfully.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<ODataValueContextOfIListOfEntryLinkTypeInfo> GetLinkDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default);
+
+    }
+
+    partial class LinkDefinitionsClient
+    {
+        public async Task GetLinkDefinitionsForEachAsync(Func<ODataValueContextOfIListOfEntryLinkTypeInfo, Task<bool>> callback, string repoId, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
+        {
+            // Initial request
+            var response = await GetLinkDefinitionsAsync(repoId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken);
+
+            // Further requests
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            {
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetLinkDefinitionsSendAsync, cancellationToken);
+            }
+        }
+
+        public async Task<ODataValueContextOfIListOfEntryLinkTypeInfo> GetLinkDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
+        {
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetLinkDefinitionsSendAsync, cancellationToken);
+        }
+    }
+}

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -134,7 +134,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update field values assigned to an entry. Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.  This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
+        /// Update the field values assigned to an entry. Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.  This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The entry ID of the entry that will have its fields updated.</param>
@@ -146,7 +146,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the tags assigned to an entry. Provide an entry ID, and get a paged listing of tags assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// Returns the tags assigned to an entry. Provide an entry ID, and get a paged listing of tags assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested entry ID.</param>
@@ -183,7 +183,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the links assigned to an entry. Provide an entry ID, and get a paged listing of links assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// Returns the links assigned to an entry. Provide an entry ID, and get a paged listing of links assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested entry ID.</param>
@@ -224,7 +224,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get information about the edoc content of an entry, without downloading the edoc in its entirety. Provide an entry ID, and get back the Content-Type and Content-Length in the response headers. This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
+        /// Returns information about the edoc content of an entry, without downloading the edoc in its entirety. Provide an entry ID, and get back the Content-Type and Content-Length in the response headers. This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested document ID.</param>
@@ -234,7 +234,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get an entry's edoc resource in a stream format. Provide an entry ID, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
+        /// Returns an entry's edoc resource in a stream format. Provide an entry ID, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested document ID.</param>
@@ -257,7 +257,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get an entry's edoc resource in a stream format while including an audit reason. Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
+        /// Returns an entry's edoc resource in a stream format while including an audit reason. Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested document ID.</param>
@@ -269,7 +269,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get dynamic field logic values with the current values of the fields in the template. Provide an entry ID and field values in the JSON body to get dynamic field logic values.  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
+        /// Returns dynamic field logic values with the current values of the fields in the template. Provide an entry ID and field values in the JSON body to get dynamic field logic values.  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested entry ID.</param>
@@ -1496,7 +1496,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Update field values assigned to an entry. Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.  This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
+        /// Update the field values assigned to an entry. Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.  This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The entry ID of the entry that will have its fields updated.</param>
@@ -1651,7 +1651,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the tags assigned to an entry. Provide an entry ID, and get a paged listing of tags assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// Returns the tags assigned to an entry. Provide an entry ID, and get a paged listing of tags assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested entry ID.</param>
@@ -2113,7 +2113,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the links assigned to an entry. Provide an entry ID, and get a paged listing of links assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// Returns the links assigned to an entry. Provide an entry ID, and get a paged listing of links assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested entry ID.</param>
@@ -2565,7 +2565,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get information about the edoc content of an entry, without downloading the edoc in its entirety. Provide an entry ID, and get back the Content-Type and Content-Length in the response headers. This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
+        /// Returns information about the edoc content of an entry, without downloading the edoc in its entirety. Provide an entry ID, and get back the Content-Type and Content-Length in the response headers. This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested document ID.</param>
@@ -2705,7 +2705,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get an entry's edoc resource in a stream format. Provide an entry ID, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
+        /// Returns an entry's edoc resource in a stream format. Provide an entry ID, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested document ID.</param>
@@ -3012,7 +3012,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get an entry's edoc resource in a stream format while including an audit reason. Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
+        /// Returns an entry's edoc resource in a stream format while including an audit reason. Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested document ID.</param>
@@ -3171,7 +3171,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get dynamic field logic values with the current values of the fields in the template. Provide an entry ID and field values in the JSON body to get dynamic field logic values.  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
+        /// Returns dynamic field logic values with the current values of the fields in the template. Provide an entry ID and field values in the JSON body to get dynamic field logic values.  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The requested entry ID.</param>
@@ -3727,7 +3727,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="top">Limits the number of items returned from a collection.</param>
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
-        /// <returns>Get trustee attribute keys successfully.</returns>
+        /// <returns>Get trustee attribute key value pairs successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<ODataValueContextOfListOfAttribute> GetTrusteeAttributeKeyValuePairsAsync(string repoId, bool? everyone = null, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
@@ -3783,7 +3783,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="top">Limits the number of items returned from a collection.</param>
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
-        /// <returns>Get trustee attribute keys successfully.</returns>
+        /// <returns>Get trustee attribute key value pairs successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<ODataValueContextOfListOfAttribute> GetTrusteeAttributeKeyValuePairsAsync(string repoId, bool? everyone = null, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
@@ -4640,12 +4640,465 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial interface ILinkDefinitionsClient
+    {
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Returns the link definitions in the repository. Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// </summary>
+        /// <param name="repoId">The requested repository ID.</param>
+        /// <param name="prefer">An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.</param>
+        /// <param name="select">Limits the properties returned in the result.</param>
+        /// <param name="orderby">Specifies the order in which items are returned. The maximum number of expressions is 5.</param>
+        /// <param name="top">Limits the number of items returned from a collection.</param>
+        /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
+        /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
+        /// <returns>Get link definitions successfully.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<ODataValueContextOfIListOfEntryLinkTypeInfo> GetLinkDefinitionsAsync(string repoId, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Returns a single field definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select
+        /// </summary>
+        /// <param name="repoId">The requested repository ID.</param>
+        /// <param name="linkTypeId">The requested link type ID.</param>
+        /// <param name="select">Limits the properties returned in the result.</param>
+        /// <returns>Get link definition successfully.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<EntryLinkTypeInfo> GetLinkDefinitionByIdAsync(string repoId, int linkTypeId, string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    internal partial class LinkDefinitionsClient : BaseClient, ILinkDefinitionsClient
+    {
+        private System.Net.Http.HttpClient _httpClient;
+        private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
+
+        public LinkDefinitionsClient(System.Net.Http.HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _settings = new System.Lazy<Newtonsoft.Json.JsonSerializerSettings>(CreateSerializerSettings);
+        }
+
+        private Newtonsoft.Json.JsonSerializerSettings CreateSerializerSettings()
+        {
+            var settings = new Newtonsoft.Json.JsonSerializerSettings();
+            UpdateJsonSerializerSettings(settings);
+            return settings;
+        }
+
+        protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
+
+        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
+
+        partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
+        partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
+        partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Returns the link definitions in the repository. Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// </summary>
+        /// <param name="repoId">The requested repository ID.</param>
+        /// <param name="prefer">An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.</param>
+        /// <param name="select">Limits the properties returned in the result.</param>
+        /// <param name="orderby">Specifies the order in which items are returned. The maximum number of expressions is 5.</param>
+        /// <param name="top">Limits the number of items returned from a collection.</param>
+        /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
+        /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
+        /// <returns>Get link definitions successfully.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<ODataValueContextOfIListOfEntryLinkTypeInfo> GetLinkDefinitionsAsync(string repoId, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (repoId == null)
+                throw new System.ArgumentNullException("repoId");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("v1/Repositories/{repoId}/LinkDefinitions?");
+            urlBuilder_.Replace("{repoId}", System.Uri.EscapeDataString(ConvertToString(repoId, System.Globalization.CultureInfo.InvariantCulture)));
+            if (select != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("$select") + "=").Append(System.Uri.EscapeDataString(ConvertToString(select, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (orderby != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("$orderby") + "=").Append(System.Uri.EscapeDataString(ConvertToString(orderby, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (top != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("$top") + "=").Append(System.Uri.EscapeDataString(ConvertToString(top, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (skip != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("$skip") + "=").Append(System.Uri.EscapeDataString(ConvertToString(skip, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            if (count != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("$count") + "=").Append(System.Uri.EscapeDataString(ConvertToString(count, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[] { false };
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+
+                    if (prefer != null)
+                        request_.Headers.TryAddWithoutValidation("Prefer", ConvertToString(prefer, System.Globalization.CultureInfo.InvariantCulture));
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    return await GetLinkDefinitionsSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        public virtual async System.Threading.Tasks.Task<ODataValueContextOfIListOfEntryLinkTypeInfo> GetLinkDefinitionsSendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ODataValueContextOfIListOfEntryLinkTypeInfo>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Invalid or bad request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Access token is invalid or expired.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Rate limit is reached.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Returns a single field definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select
+        /// </summary>
+        /// <param name="repoId">The requested repository ID.</param>
+        /// <param name="linkTypeId">The requested link type ID.</param>
+        /// <param name="select">Limits the properties returned in the result.</param>
+        /// <returns>Get link definition successfully.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<EntryLinkTypeInfo> GetLinkDefinitionByIdAsync(string repoId, int linkTypeId, string select = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (repoId == null)
+                throw new System.ArgumentNullException("repoId");
+
+            if (linkTypeId == null)
+                throw new System.ArgumentNullException("linkTypeId");
+
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append("v1/Repositories/{repoId}/LinkDefinitions/{linkTypeId}?");
+            urlBuilder_.Replace("{repoId}", System.Uri.EscapeDataString(ConvertToString(repoId, System.Globalization.CultureInfo.InvariantCulture)));
+            urlBuilder_.Replace("{linkTypeId}", System.Uri.EscapeDataString(ConvertToString(linkTypeId, System.Globalization.CultureInfo.InvariantCulture)));
+            if (select != null)
+            {
+                urlBuilder_.Append(System.Uri.EscapeDataString("$select") + "=").Append(System.Uri.EscapeDataString(ConvertToString(select, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
+            }
+            urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[] { false };
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    return await GetLinkDefinitionByIdSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        public virtual async System.Threading.Tasks.Task<EntryLinkTypeInfo> GetLinkDefinitionByIdSendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<EntryLinkTypeInfo>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Invalid or bad request.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Access token is invalid or expired.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Requested link type definition ID not found", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Rate limit is reached.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        protected struct ObjectResponseResult<T>
+        {
+            public ObjectResponseResult(T responseObject, string responseText)
+            {
+                this.Object = responseObject;
+                this.Text = responseText;
+            }
+
+            public T Object { get; }
+
+            public string Text { get; }
+        }
+
+        public bool ReadResponseAsString { get; set; }
+
+        protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
+        {
+            if (response == null || response.Content == null)
+            {
+                return new ObjectResponseResult<T>(default(T), string.Empty);
+            }
+
+            if (ReadResponseAsString)
+            {
+                var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    var typedBody = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(responseText, JsonSerializerSettings);
+                    return new ObjectResponseResult<T>(typedBody, responseText);
+                }
+                catch (Newtonsoft.Json.JsonException exception)
+                {
+                    var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
+                    throw new ApiException(message, (int)response.StatusCode, responseText, headers, exception);
+                }
+            }
+            else
+            {
+                try
+                {
+                    using (var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    using (var streamReader = new System.IO.StreamReader(responseStream))
+                    using (var jsonTextReader = new Newtonsoft.Json.JsonTextReader(streamReader))
+                    {
+                        var serializer = Newtonsoft.Json.JsonSerializer.Create(JsonSerializerSettings);
+                        var typedBody = serializer.Deserialize<T>(jsonTextReader);
+                        return new ObjectResponseResult<T>(typedBody, string.Empty);
+                    }
+                }
+                catch (Newtonsoft.Json.JsonException exception)
+                {
+                    var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
+                    throw new ApiException(message, (int)response.StatusCode, string.Empty, headers, exception);
+                }
+            }
+        }
+
+        private string ConvertToString(object value, System.Globalization.CultureInfo cultureInfo)
+        {
+            if (value == null)
+            {
+                return "";
+            }
+
+            if (value is System.Enum)
+            {
+                var name = System.Enum.GetName(value.GetType(), value);
+                if (name != null)
+                {
+                    var field = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
+                    if (field != null)
+                    {
+                        var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field, typeof(System.Runtime.Serialization.EnumMemberAttribute))
+                            as System.Runtime.Serialization.EnumMemberAttribute;
+                        if (attribute != null)
+                        {
+                            return attribute.Value != null ? attribute.Value : name;
+                        }
+                    }
+
+                    var converted = System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
+                    return converted == null ? string.Empty : converted;
+                }
+            }
+            else if (value is bool)
+            {
+                return System.Convert.ToString((bool)value, cultureInfo).ToLowerInvariant();
+            }
+            else if (value is byte[])
+            {
+                return System.Convert.ToBase64String((byte[])value);
+            }
+            else if (value.GetType().IsArray)
+            {
+                var array = System.Linq.Enumerable.OfType<object>((System.Array)value);
+                return string.Join(",", System.Linq.Enumerable.Select(array, o => ConvertToString(o, cultureInfo)));
+            }
+
+            var result = System.Convert.ToString(value, cultureInfo);
+            return result == null ? "" : result;
+        }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
     public partial interface IRepositoriesClient
     {
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the repository resource list that current user has access to.
+        /// Returns the repository resource list that current user has access to.
         /// </summary>
         /// <returns>Get the respository resource list successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -4682,7 +5135,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Get the repository resource list that current user has access to.
+        /// Returns the repository resource list that current user has access to.
         /// </summary>
         /// <returns>Get the respository resource list successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -4741,12 +5194,6 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     return objectResponse_.Object;
-                }
-                else
-                if (status_ == 204)
-                {
-                    string responseText_ = (response_.Content == null) ? string.Empty : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    throw new ApiException("Account does not have access to any repository", status_, responseText_, headers_, null);
                 }
                 else
                 if (status_ == 400)
@@ -5265,6 +5712,16 @@ namespace Laserfiche.Repository.Api.Client
                     return objectResponse_.Object;
                 }
                 else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Access token is invalid or expired.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
                 {
                     var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                     throw new ApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
@@ -5388,8 +5845,8 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// Returns the status of an operation. Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant). OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.
         /// </summary>
-        /// <param name="repoId">The requested repository ID.</param>
-        /// <param name="operationToken">The operation token.</param>
+        /// <param name="repoId">The requested repository ID</param>
+        /// <param name="operationToken">The operation token</param>
         /// <returns>Get completed operation status with no result successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<OperationProgress> GetOperationStatusAndProgressAsync(string repoId, string operationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -5398,7 +5855,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// Cancels an operation. Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary. Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.
         /// </summary>
-        /// <param name="repoId">The requested repository ID.</param>
+        /// <param name="repoId">The requested repository ID</param>
         /// <param name="operationToken">The operation token</param>
         /// <returns>Cancel operation successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -5437,8 +5894,8 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// Returns the status of an operation. Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant). OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.
         /// </summary>
-        /// <param name="repoId">The requested repository ID.</param>
-        /// <param name="operationToken">The operation token.</param>
+        /// <param name="repoId">The requested repository ID</param>
+        /// <param name="operationToken">The operation token</param>
         /// <returns>Get completed operation status with no result successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<OperationProgress> GetOperationStatusAndProgressAsync(string repoId, string operationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -5563,7 +6020,7 @@ namespace Laserfiche.Repository.Api.Client
                     {
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
-                    throw new ApiException<ProblemDetails>("Request operation token not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                    throw new ApiException<ProblemDetails>("Request operationToken not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -5592,7 +6049,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// Cancels an operation. Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary. Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.
         /// </summary>
-        /// <param name="repoId">The requested repository ID.</param>
+        /// <param name="repoId">The requested repository ID</param>
         /// <param name="operationToken">The operation token</param>
         /// <returns>Cancel operation successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
@@ -5693,7 +6150,7 @@ namespace Laserfiche.Repository.Api.Client
                     {
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
-                    throw new ApiException<ProblemDetails>("Request operation token not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                    throw new ApiException<ProblemDetails>("Request operationToken not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -6145,7 +6602,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Returns the context hits associated with a search result entry. Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry. Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// Returns the context hits associated with a search result entry. Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="searchToken">The requested searchToken.</param>
@@ -6797,7 +7254,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Returns the context hits associated with a search result entry. Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry. Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+        /// Returns the context hits associated with a search result entry. Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="searchToken">The requested searchToken.</param>
@@ -7913,7 +8370,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="top">Limits the number of items returned from a collection.</param>
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
-        /// <returns>Get field definitions successfully.</returns>
+        /// <returns>Get template field definitions successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<ODataValueContextOfIListOfTemplateFieldInfo> GetTemplateFieldDefinitionsAsync(string repoId, int templateId, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
@@ -7931,7 +8388,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="top">Limits the number of items returned from a collection.</param>
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
-        /// <returns>Get field definitions successfully.</returns>
+        /// <returns>Get template field definitions successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<ODataValueContextOfIListOfTemplateFieldInfo> GetTemplateFieldDefinitionsByTemplateNameAsync(string repoId, string templateName, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
@@ -8296,7 +8753,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="top">Limits the number of items returned from a collection.</param>
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
-        /// <returns>Get field definitions successfully.</returns>
+        /// <returns>Get template field definitions successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<ODataValueContextOfIListOfTemplateFieldInfo> GetTemplateFieldDefinitionsAsync(string repoId, int templateId, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
@@ -8467,7 +8924,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="top">Limits the number of items returned from a collection.</param>
         /// <param name="skip">Excludes the specified number of items of the queried collection from the result.</param>
         /// <param name="count">Indicates whether the total count of items within a collection are returned in the result.</param>
-        /// <returns>Get field definitions successfully.</returns>
+        /// <returns>Get template field definitions successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<ODataValueContextOfIListOfTemplateFieldInfo> GetTemplateFieldDefinitionsByTemplateNameAsync(string repoId, string templateName, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
@@ -8971,29 +9428,9 @@ namespace Laserfiche.Repository.Api.Client
 
     }
 
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class LinkToUpdate
-    {
-        /// <summary>
-        /// The id of the link assigned to the entry.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("linkTypeId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int LinkTypeId { get; set; }
-
-        /// <summary>
-        /// The id of the other source linked to the entry.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("otherSourceId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int OtherSourceId { get; set; }
-
-        /// <summary>
-        /// Whether the entry is the source for the link.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("isSource", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool IsSource { get; set; }
-
-    }
-
+    /// <summary>
+    /// The request body containing fields that will be assigned to the entry.
+    /// </summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
     public partial class FieldToUpdate
     {
@@ -9019,6 +9456,29 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("position", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Position { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class LinkToUpdate
+    {
+        /// <summary>
+        /// The id of the link assigned to the entry.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("linkTypeId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int LinkTypeId { get; set; }
+
+        /// <summary>
+        /// The id of the other source linked to the entry.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("otherSourceId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int OtherSourceId { get; set; }
+
+        /// <summary>
+        /// Whether the entry is the source for the link.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isSource", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsSource { get; set; }
 
     }
 
@@ -9312,6 +9772,63 @@ namespace Laserfiche.Repository.Api.Client
     {
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<WFieldInfo> Value { get; set; }
+
+    }
+
+    /// <summary>
+    /// A wrapper around the ODataValue with extra odata.nextLink and odata.count.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class ODataValueContextOfIListOfEntryLinkTypeInfo : ODataValueOfIListOfEntryLinkTypeInfo
+    {
+        /// <summary>
+        /// It contains a URL that allows retrieving the next subset of the requested collection.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("@odata.nextLink", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string OdataNextLink { get; set; }
+
+        /// <summary>
+        /// It contains the count of a collection of entities or a collection of entity references.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int OdataCount { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class ODataValueOfIListOfEntryLinkTypeInfo
+    {
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.Collections.Generic.ICollection<EntryLinkTypeInfo> Value { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class EntryLinkTypeInfo
+    {
+        /// <summary>
+        /// The ID of the entry link type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("linkTypeId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int LinkTypeId { get; set; }
+
+        /// <summary>
+        /// The label for the source entry in the link type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("sourceLabel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string SourceLabel { get; set; }
+
+        /// <summary>
+        /// The label for the target entry in the link type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("targetLabel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string TargetLabel { get; set; }
+
+        /// <summary>
+        /// The description of the link type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("linkTypeDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LinkTypeDescription { get; set; }
 
     }
 
@@ -9939,6 +10456,12 @@ namespace Laserfiche.Repository.Api.Client
         public string LinkTypeDescription { get; set; }
 
         /// <summary>
+        /// The ID of the entry link type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("linkTypeId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int LinkTypeId { get; set; }
+
+        /// <summary>
         /// The properties for the entry link.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("linkProperties", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -10153,21 +10676,54 @@ namespace Laserfiche.Repository.Api.Client
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
     public partial class OperationProgress
     {
+        /// <summary>
+        /// The operation token of the operation associated with this OperationProgress.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("operationToken", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string OperationToken { get; set; }
 
+        /// <summary>
+        /// The type of the operation associated with this OperationProgress.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("operationType", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string OperationType { get; set; }
 
+        /// <summary>
+        /// Determines what percentage of the execution of the associated operation is completed.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("percentComplete", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int PercentComplete { get; set; }
 
+        /// <summary>
+        /// The status of the operation associated with this OperationProgress.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("status", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
         public OperationStatus Status { get; set; }
 
+        /// <summary>
+        /// The list of errors occurred during the execution of the associated operation.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("errors", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.Generic.ICollection<OperationErrorItem> Errors { get; set; }
+
+        /// <summary>
+        /// The URI which can be used (via api call) to access the result(s) of the associated operation.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("redirectUri", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string RedirectUri { get; set; }
+
+        /// <summary>
+        /// The timestamp representing when the associated operation's execution is started.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("startTimestamp", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTimeOffset StartTimestamp { get; set; }
+
+        /// <summary>
+        /// The timestamp representing the last time when the associated task's status has changed.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("statusTimestamp", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTimeOffset StatusTimestamp { get; set; }
 
     }
 
@@ -10195,9 +10751,15 @@ namespace Laserfiche.Repository.Api.Client
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
     public partial class OperationErrorItem
     {
+        /// <summary>
+        /// The ID of the entry to which the error is related. 
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("objectId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int ObjectId { get; set; }
 
+        /// <summary>
+        /// The short description of the error.
+        /// </summary>
         [Newtonsoft.Json.JsonProperty("errorMessage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string ErrorMessage { get; set; }
 

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -4660,7 +4660,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Returns a single field definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select
+        /// Returns a single link definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="linkTypeId">The requested link type ID.</param>
@@ -4850,7 +4850,7 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Returns a single field definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select
+        /// Returns a single link definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="linkTypeId">The requested link type ID.</param>

--- a/src/IRepositoryApiClient.cs
+++ b/src/IRepositoryApiClient.cs
@@ -29,6 +29,10 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         IFieldDefinitionsClient FieldDefinitionsClient { get; }
         /// <summary>
+        /// The Laserfiche Repository Link Definitions API client.
+        /// </summary>
+        ILinkDefinitionsClient LinkDefinitionsClient { get; }
+        /// <summary>
         /// The Laserfiche Repository Repositories API client.
         /// </summary>
         IRepositoriesClient RepositoriesClient { get; }

--- a/src/Laserfiche.Repository.Api.Client.csproj
+++ b/src/Laserfiche.Repository.Api.Client.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <Authors>Laserfiche</Authors>
     <Description>.NET API that enables easy and secure access to Laserfiche Repository.</Description>
     <Copyright>Copyright 2022 Laserfiche</Copyright>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Laserfiche.Api.Client.Core" Version="1.1.0-beta-2505455597" />
+    <PackageReference Include="Laserfiche.Api.Client.Core" Version="1.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/src/RepositoryApiClient.cs
+++ b/src/RepositoryApiClient.cs
@@ -29,6 +29,8 @@ namespace Laserfiche.Repository.Api.Client
         /// <inheritdoc/>
         public IFieldDefinitionsClient FieldDefinitionsClient { get; }
         /// <inheritdoc/>
+        public ILinkDefinitionsClient LinkDefinitionsClient { get; }
+        /// <inheritdoc/>
         public IRepositoriesClient RepositoriesClient { get; }
         /// <inheritdoc/>
         public ISearchesClient SearchesClient { get; }
@@ -50,6 +52,7 @@ namespace Laserfiche.Repository.Api.Client
             AuditReasonsClient = new AuditReasonsClient(_httpClient);
             EntriesClient = new EntriesClient(_httpClient);
             FieldDefinitionsClient = new FieldDefinitionsClient(_httpClient);
+            LinkDefinitionsClient = new LinkDefinitionsClient(_httpClient);
             RepositoriesClient = new RepositoriesClient(_httpClient);
             SearchesClient = new SearchesClient(_httpClient);
             ServerSessionClient = new ServerSessionClient(_httpClient);

--- a/swagger.json
+++ b/swagger.json
@@ -821,8 +821,8 @@
         "tags": [
           "LinkDefinitions"
         ],
-        "summary": "Returns a single field definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select",
-        "description": "- Returns a single field definition associated with the specified ID.\n- Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.\n- Allowed OData query options: Select",
+        "summary": "Returns a single link definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select",
+        "description": "- Returns a single link definition associated with the specified ID.\n- Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.\n- Allowed OData query options: Select",
         "operationId": "GetLinkDefinitionById",
         "parameters": [
           {

--- a/swagger.json
+++ b/swagger.json
@@ -17,6 +17,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Creates a new document in the specified folder. Optionally sets metadata and electronic document component. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.",
         "description": "- Creates a new document in the specified folder.\n- Optionally sets metadata and electronic document component.\n- Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.",
         "operationId": "ImportDocument",
         "parameters": [
@@ -171,8 +172,7 @@
               }
             }
           }
-        },
-        "summary": "Creates a new document in the specified folder. Optionally sets metadata and electronic document component. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Attributes": {
@@ -266,7 +266,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Get trustee attribute keys successfully.",
+            "description": "Get trustee attribute key value pairs  successfully.",
             "content": {
               "application/json": {
                 "schema": {
@@ -426,6 +426,7 @@
         "tags": [
           "FieldDefinitions"
         ],
+        "summary": "Returns a single field definition associated with the specified ID.  Useful when a route provides a minimal amount of details and more information about the specific field definition is needed. Allowed OData query options: Select",
         "description": "- Returns a single field definition associated with the specified ID. \n- Useful when a route provides a minimal amount of details and more information about the specific field definition is needed.\n- Allowed OData query options: Select",
         "operationId": "GetFieldDefinitionById",
         "parameters": [
@@ -533,8 +534,7 @@
               }
             }
           }
-        },
-        "summary": "Returns a single field definition associated with the specified ID.  Useful when a route provides a minimal amount of details and more information about the specific field definition is needed. Allowed OData query options: Select"
+        }
       }
     },
     "/v1/Repositories/{repoId}/FieldDefinitions": {
@@ -542,6 +542,7 @@
         "tags": [
           "FieldDefinitions"
         ],
+        "summary": "Returns a paged listing of field definitions available in the specified repository. Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "description": "- Returns a paged listing of field definitions available in the specified repository.\n- Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetFieldDefinitions",
         "parameters": [
@@ -678,8 +679,246 @@
               }
             }
           }
-        },
-        "summary": "Returns a paged listing of field definitions available in the specified repository. Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
+      }
+    },
+    "/v1/Repositories/{repoId}/LinkDefinitions": {
+      "get": {
+        "tags": [
+          "LinkDefinitions"
+        ],
+        "summary": "Returns the link definitions in the repository. Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "description": "- Returns the link definitions in the repository.\n- Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "operationId": "GetLinkDefinitions",
+        "parameters": [
+          {
+            "name": "repoId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "Prefer",
+            "x-originalName": "prefer",
+            "in": "header",
+            "description": "An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "description": "Limits the number of items returned from a collection.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 6
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "description": "Excludes the specified number of items of the queried collection from the result.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 7
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Indicates whether the total count of items within a collection are returned in the result.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 8
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get link definitions successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ODataValueContextOfIListOfEntryLinkTypeInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/Repositories/{repoId}/LinkDefinitions/{linkTypeId}": {
+      "get": {
+        "tags": [
+          "LinkDefinitions"
+        ],
+        "summary": "Returns a single field definition associated with the specified ID. Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed. Allowed OData query options: Select",
+        "description": "- Returns a single field definition associated with the specified ID.\n- Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.\n- Allowed OData query options: Select",
+        "operationId": "GetLinkDefinitionById",
+        "parameters": [
+          {
+            "name": "repoId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "linkTypeId",
+            "in": "path",
+            "required": true,
+            "description": "The requested link type ID.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get link definition successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntryLinkTypeInfo"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Requested link type definition ID not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}": {
@@ -687,6 +926,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Returns a single entry object. Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc. Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.",
         "description": "- Returns a single entry object.\n- Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.\n- Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.",
         "operationId": "GetEntry",
         "parameters": [
@@ -783,13 +1023,13 @@
               }
             }
           }
-        },
-        "summary": "Returns a single entry object. Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc. Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties."
+        }
       },
       "delete": {
         "tags": [
           "Entries"
         ],
+        "summary": "Begins a task to delete an entry, and returns an operationToken. Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately. Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.",
         "description": "- Begins a task to delete an entry, and returns an operationToken.\n- Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately.\n- Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.",
         "operationId": "DeleteEntryInfo",
         "parameters": [
@@ -878,13 +1118,13 @@
               }
             }
           }
-        },
-        "summary": "Begins a task to delete an entry, and returns an operationToken. Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately. Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route."
+        }
       },
       "patch": {
         "tags": [
           "Entries"
         ],
+        "summary": "Moves and/or renames an entry. Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.",
         "description": "- Moves and/or renames an entry.\n- Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.\n- Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.",
         "operationId": "MoveOrRenameDocument",
         "parameters": [
@@ -1047,8 +1287,7 @@
               }
             }
           }
-        },
-        "summary": "Moves and/or renames an entry. Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children": {
@@ -1056,6 +1295,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Returns the children entries of a folder in the repository. Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: \"PropertyName direction,PropertyName2 direction\". Sort order can be either value \"asc\" or \"desc\". Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route. Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names. If field values are requested, only the first value is returned if it is a multi value field. Null or Empty field values should not be used to determine if a field is assigned to the entry.",
         "description": "- Returns the children entries of a folder in the repository.\n- Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: \"PropertyName direction,PropertyName2 direction\". Sort order can be either value \"asc\" or \"desc\". Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route.\n- Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names.\n- If field values are requested, only the first value is returned if it is a multi value field.\n- Null or Empty field values should not be used to determine if a field is assigned to the entry.",
         "operationId": "GetEntryListing",
         "parameters": [
@@ -1246,13 +1486,13 @@
               }
             }
           }
-        },
-        "summary": "Returns the children entries of a folder in the repository. Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: \"PropertyName direction,PropertyName2 direction\". Sort order can be either value \"asc\" or \"desc\". Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route. Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names. If field values are requested, only the first value is returned if it is a multi value field. Null or Empty field values should not be used to determine if a field is assigned to the entry."
+        }
       },
       "post": {
         "tags": [
           "Entries"
         ],
+        "summary": "Create/copy a new child entry in the designated folder. Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.",
         "description": "- Create/copy a new child entry in the designated folder.\n- Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder.\n- Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.",
         "operationId": "CreateOrCopyEntry",
         "parameters": [
@@ -1408,8 +1648,7 @@
               }
             }
           }
-        },
-        "summary": "Create/copy a new child entry in the designated folder. Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/fields": {
@@ -1417,6 +1656,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Returns the fields assigned to an entry. Provide an entry ID, and get a paged listing of all fields assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "description": "- Returns the fields assigned to an entry.\n- Provide an entry ID, and get a paged listing of all fields assigned to that entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetFieldValues",
         "parameters": [
@@ -1584,15 +1824,14 @@
               }
             }
           }
-        },
-        "summary": "Returns the fields assigned to an entry. Provide an entry ID, and get a paged listing of all fields assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       },
       "put": {
         "tags": [
           "Entries"
         ],
-        "summary": "Update field values assigned to an entry. Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.  This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.",
-        "description": "- Update field values assigned to an entry.\n- Provide the new field values to assign to the entry, and remove/reset all previously assigned field values. \n- This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.",
+        "summary": "Update the field values assigned to an entry. Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.  This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.",
+        "description": "- Update the field values assigned to an entry.\n- Provide the new field values to assign to the entry, and remove/reset all previously assigned field values. \n- This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.",
         "operationId": "AssignFieldValues",
         "parameters": [
           {
@@ -1722,7 +1961,8 @@
         "tags": [
           "Entries"
         ],
-        "description": "- Get the tags assigned to an entry.\n- Provide an entry ID, and get a paged listing of tags assigned to that entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "summary": "Returns the tags assigned to an entry. Provide an entry ID, and get a paged listing of tags assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "description": "- Returns the tags assigned to an entry.\n- Provide an entry ID, and get a paged listing of tags assigned to that entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetTagsAssignedToEntry",
         "parameters": [
           {
@@ -1868,13 +2108,13 @@
               }
             }
           }
-        },
-        "summary": "Get the tags assigned to an entry. Provide an entry ID, and get a paged listing of tags assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       },
       "put": {
         "tags": [
           "Entries"
         ],
+        "summary": "Assign tags to an entry. Provide an entry ID and a list of tags to assign to that entry. This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.",
         "description": "- Assign tags to an entry.\n- Provide an entry ID and a list of tags to assign to that entry.\n- This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.",
         "operationId": "AssignTags",
         "parameters": [
@@ -1983,8 +2223,7 @@
               }
             }
           }
-        },
-        "summary": "Assign tags to an entry. Provide an entry ID and a list of tags to assign to that entry. This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/links": {
@@ -1992,6 +2231,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Assign links to an entry. Provide an entry ID and a list of links to assign to that entry. This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.",
         "description": "- Assign links to an entry.\n- Provide an entry ID and a list of links to assign to that entry.\n- This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.",
         "operationId": "AssignEntryLinks",
         "parameters": [
@@ -2102,14 +2342,14 @@
               }
             }
           }
-        },
-        "summary": "Assign links to an entry. Provide an entry ID and a list of links to assign to that entry. This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry."
+        }
       },
       "get": {
         "tags": [
           "Entries"
         ],
-        "description": "- Get the links assigned to an entry.\n- Provide an entry ID, and get a paged listing of links assigned to that entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "summary": "Returns the links assigned to an entry. Provide an entry ID, and get a paged listing of links assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "description": "- Returns the links assigned to an entry.\n- Provide an entry ID, and get a paged listing of links assigned to that entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetLinkValuesFromEntry",
         "parameters": [
           {
@@ -2255,8 +2495,7 @@
               }
             }
           }
-        },
-        "summary": "Get the links assigned to an entry. Provide an entry ID, and get a paged listing of links assigned to that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/CopyAsync": {
@@ -2264,6 +2503,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Copy a new child entry in the designated folder async, and potentially return an operationToken. Provide the parent folder ID, and copy an entry as a child of the designated folder. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.  The status of the operation can be checked via the Tasks/{operationToken} route.",
         "description": "- Copy a new child entry in the designated folder async, and potentially return an operationToken.\n- Provide the parent folder ID, and copy an entry as a child of the designated folder.\n- Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. \n- The status of the operation can be checked via the Tasks/{operationToken} route.",
         "operationId": "CopyEntryAsync",
         "parameters": [
@@ -2382,8 +2622,7 @@
               }
             }
           }
-        },
-        "summary": "Copy a new child entry in the designated folder async, and potentially return an operationToken. Provide the parent folder ID, and copy an entry as a child of the designated folder. Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.  The status of the operation can be checked via the Tasks/{operationToken} route."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc": {
@@ -2391,6 +2630,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Delete the edoc associated with the provided entry ID.",
         "description": "- Delete the edoc associated with the provided entry ID.",
         "operationId": "DeleteDocument",
         "parameters": [
@@ -2487,14 +2727,14 @@
               }
             }
           }
-        },
-        "summary": "Delete the edoc associated with the provided entry ID."
+        }
       },
       "head": {
         "tags": [
           "Entries"
         ],
-        "description": "- Get information about the edoc content of an entry, without downloading the edoc in its entirety.\n- Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.\n- This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.",
+        "summary": "Returns information about the edoc content of an entry, without downloading the edoc in its entirety. Provide an entry ID, and get back the Content-Type and Content-Length in the response headers. This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.",
+        "description": "- Returns information about the edoc content of an entry, without downloading the edoc in its entirety.\n- Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.\n- This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.",
         "operationId": "GetDocumentContentType",
         "parameters": [
           {
@@ -2583,14 +2823,14 @@
               }
             }
           }
-        },
-        "summary": "Get information about the edoc content of an entry, without downloading the edoc in its entirety. Provide an entry ID, and get back the Content-Type and Content-Length in the response headers. This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry."
+        }
       },
       "get": {
         "tags": [
           "Entries"
         ],
-        "description": "- Get an entry's edoc resource in a stream format.\n- Provide an entry ID, and get the edoc resource as part of the response content.\n- Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.",
+        "summary": "Returns an entry's edoc resource in a stream format. Provide an entry ID, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.",
+        "description": "- Returns an entry's edoc resource in a stream format.\n- Provide an entry ID, and get the edoc resource as part of the response content.\n- Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.",
         "operationId": "ExportDocument",
         "parameters": [
           {
@@ -2709,8 +2949,7 @@
               }
             }
           }
-        },
-        "summary": "Get an entry's edoc resource in a stream format. Provide an entry ID, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/pages": {
@@ -2718,6 +2957,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted. Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: \"1,2,3\", \"1-3,5\", \"2-7,10-12.\"",
         "description": "- Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.\n- Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: \"1,2,3\", \"1-3,5\", \"2-7,10-12.\"",
         "operationId": "DeletePages",
         "parameters": [
@@ -2824,8 +3064,7 @@
               }
             }
           }
-        },
-        "summary": "Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted. Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: \"1,2,3\", \"1-3,5\", \"2-7,10-12.\""
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/GetEdocWithAuditReason": {
@@ -2833,7 +3072,8 @@
         "tags": [
           "Entries"
         ],
-        "description": "- Get an entry's edoc resource in a stream format while including an audit reason.\n- Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.\n- Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.",
+        "summary": "Returns an entry's edoc resource in a stream format while including an audit reason. Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.",
+        "description": "- Returns an entry's edoc resource in a stream format while including an audit reason.\n- Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.\n- Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.",
         "operationId": "ExportDocumentWithAuditReason",
         "parameters": [
           {
@@ -2963,8 +3203,7 @@
               }
             }
           }
-        },
-        "summary": "Get an entry's edoc resource in a stream format while including an audit reason. Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content. Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/fields/GetDynamicFieldLogicValue": {
@@ -2972,7 +3211,8 @@
         "tags": [
           "Entries"
         ],
-        "description": "- Get dynamic field logic values with the current values of the fields in the template.\n- Provide an entry ID and field values in the JSON body to get dynamic field logic values.\n Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.",
+        "summary": "Returns dynamic field logic values with the current values of the fields in the template. Provide an entry ID and field values in the JSON body to get dynamic field logic values.  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.",
+        "description": "- Returns dynamic field logic values with the current values of the fields in the template.\n- Provide an entry ID and field values in the JSON body to get dynamic field logic values.\n Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.",
         "operationId": "GetDynamicFieldValues",
         "parameters": [
           {
@@ -3075,8 +3315,7 @@
               }
             }
           }
-        },
-        "summary": "Get dynamic field logic values with the current values of the fields in the template. Provide an entry ID and field values in the JSON body to get dynamic field logic values.  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Entries/{entryId}/template": {
@@ -3084,6 +3323,7 @@
         "tags": [
           "Entries"
         ],
+        "summary": "Remove the currently assigned template from the specified entry. Provide an entry ID to clear template value on. If the entry does not have a template assigned, no change will be made.",
         "description": "- Remove the currently assigned template from the specified entry.\n- Provide an entry ID to clear template value on.\n- If the entry does not have a template assigned, no change will be made.",
         "operationId": "DeleteAssignedTemplate",
         "parameters": [
@@ -3180,13 +3420,13 @@
               }
             }
           }
-        },
-        "summary": "Remove the currently assigned template from the specified entry. Provide an entry ID to clear template value on. If the entry does not have a template assigned, no change will be made."
+        }
       },
       "put": {
         "tags": [
           "Entries"
         ],
+        "summary": "Assign a template to an entry. Provide an entry ID, template name, and a list of template fields to assign to that entry. Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.",
         "description": "- Assign a template to an entry.\n- Provide an entry ID, template name, and a list of template fields to assign to that entry.\n- Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.",
         "operationId": "WriteTemplateValueToEntry",
         "parameters": [
@@ -3348,8 +3588,7 @@
               }
             }
           }
-        },
-        "summary": "Assign a template to an entry. Provide an entry ID, template name, and a list of template fields to assign to that entry. Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified."
+        }
       }
     },
     "/v1/Repositories": {
@@ -3357,7 +3596,8 @@
         "tags": [
           "Repositories"
         ],
-        "description": "- Get the repository resource list that current user has access to.",
+        "summary": "Returns the repository resource list that current user has access to.",
+        "description": "- Returns the repository resource list that current user has access to.",
         "operationId": "GetRepositoryList",
         "responses": {
           "200": {
@@ -3372,9 +3612,6 @@
                 }
               }
             }
-          },
-          "204": {
-            "description": "Account does not have access to any repository"
           },
           "400": {
             "description": "Invalid or bad request.",
@@ -3406,8 +3643,7 @@
               }
             }
           }
-        },
-        "summary": "Get the repository resource list that current user has access to."
+        }
       }
     },
     "/v1/Repositories/{repoId}/ServerSession/Invalidate": {
@@ -3415,6 +3651,7 @@
         "tags": [
           "ServerSession"
         ],
+        "summary": "Invalidates the server session. Acts as a \"logout\" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.",
         "description": "- Invalidates the server session.\n- Acts as a \"logout\" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.",
         "operationId": "InvalidateServerSession",
         "parameters": [
@@ -3480,8 +3717,7 @@
               }
             }
           }
-        },
-        "summary": "Invalidates the server session. Acts as a \"logout\" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session."
+        }
       }
     },
     "/v1/Repositories/{repoId}/ServerSession/Refresh": {
@@ -3489,6 +3725,7 @@
         "tags": [
           "ServerSession"
         ],
+        "summary": "Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.",
         "description": "- Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires.\n- When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.",
         "operationId": "RefreshServerSession",
         "parameters": [
@@ -3554,8 +3791,7 @@
               }
             }
           }
-        },
-        "summary": "Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token."
+        }
       }
     },
     "/v1/Repositories/{repoId}/ServerSession/Create": {
@@ -3563,6 +3799,7 @@
         "tags": [
           "ServerSession"
         ],
+        "summary": "Deprecated. This function is a no-op, always returns 200.",
         "description": "- Deprecated. This function is a no-op, always returns 200.",
         "operationId": "CreateServerSession",
         "parameters": [
@@ -3587,9 +3824,18 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
-        },
-        "summary": "Deprecated. This function is a no-op, always returns 200."
+        }
       }
     },
     "/v1/Repositories/{repoId}/Tasks/{operationToken}": {
@@ -3597,6 +3843,7 @@
         "tags": [
           "Tasks"
         ],
+        "summary": "Returns the status of an operation. Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant). OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.",
         "description": "- Returns the status of an operation.\n- Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant).\n- OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.",
         "operationId": "GetOperationStatusAndProgress",
         "parameters": [
@@ -3604,7 +3851,7 @@
             "name": "repoId",
             "in": "path",
             "required": true,
-            "description": "The requested repository ID.",
+            "description": "The requested repository ID",
             "schema": {
               "type": "string"
             },
@@ -3614,7 +3861,7 @@
             "name": "operationToken",
             "in": "path",
             "required": true,
-            "description": "The operation token.",
+            "description": "The operation token",
             "schema": {
               "type": "string"
             },
@@ -3683,7 +3930,7 @@
             }
           },
           "404": {
-            "description": "Request operation token not found.",
+            "description": "Request operationToken not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3702,13 +3949,13 @@
               }
             }
           }
-        },
-        "summary": "Returns the status of an operation. Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant). OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed."
+        }
       },
       "delete": {
         "tags": [
           "Tasks"
         ],
+        "summary": "Cancels an operation. Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary. Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.",
         "description": "- Cancels an operation.\n- Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary.\n- Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.",
         "operationId": "CancelOperation",
         "parameters": [
@@ -3716,7 +3963,7 @@
             "name": "repoId",
             "in": "path",
             "required": true,
-            "description": "The requested repository ID.",
+            "description": "The requested repository ID",
             "schema": {
               "type": "string"
             },
@@ -3726,7 +3973,7 @@
             "name": "operationToken",
             "in": "path",
             "required": true,
-            "description": "The operation token ",
+            "description": "The operation token",
             "schema": {
               "type": "string"
             },
@@ -3768,7 +4015,7 @@
             }
           },
           "404": {
-            "description": "Request operation token not found.",
+            "description": "Request operationToken not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3787,8 +4034,7 @@
               }
             }
           }
-        },
-        "summary": "Cancels an operation. Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary. Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled."
+        }
       }
     },
     "/v1/Repositories/{repoId}/AuditReasons": {
@@ -4389,7 +4635,8 @@
         "tags": [
           "Searches"
         ],
-        "description": "- Returns the context hits associated with a search result entry.\n- Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.\n- Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "summary": "Returns the context hits associated with a search result entry. Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
+        "description": "- Returns the context hits associated with a search result entry.\n- Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetSearchContextHits",
         "parameters": [
           {
@@ -4545,8 +4792,7 @@
               }
             }
           }
-        },
-        "summary": "Returns the context hits associated with a search result entry. Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry. Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       }
     },
     "/v1/Repositories/{repoId}/SimpleSearches": {
@@ -4554,6 +4800,7 @@
         "tags": [
           "SimpleSearches"
         ],
+        "summary": "Runs a \"simple\" search operation on the repository. Returns a truncated search result listing. Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches. Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names. If field values are requested, only the first value is returned if it is a multi value field. Null or Empty field values should not be used to determine if a field is assigned to the entry.",
         "description": "- Runs a \"simple\" search operation on the repository.\n- Returns a truncated search result listing.\n- Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches.\n- Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.\n- If field values are requested, only the first value is returned if it is a multi value field.\n- Null or Empty field values should not be used to determine if a field is assigned to the entry.",
         "operationId": "CreateSimpleSearchOperation",
         "parameters": [
@@ -4712,8 +4959,7 @@
               }
             }
           }
-        },
-        "summary": "Runs a \"simple\" search operation on the repository. Returns a truncated search result listing. Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches. Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names. If field values are requested, only the first value is returned if it is a multi value field. Null or Empty field values should not be used to determine if a field is assigned to the entry."
+        }
       }
     },
     "/v1/Repositories/{repoId}/TagDefinitions": {
@@ -4721,6 +4967,7 @@
         "tags": [
           "TagDefinitions"
         ],
+        "summary": "Returns all tag definitions in the repository. Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "description": "- Returns all tag definitions in the repository.\n- Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetTagDefinitions",
         "parameters": [
@@ -4857,8 +5104,7 @@
               }
             }
           }
-        },
-        "summary": "Returns all tag definitions in the repository. Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       }
     },
     "/v1/Repositories/{repoId}/TagDefinitions/{tagId}": {
@@ -4866,6 +5112,7 @@
         "tags": [
           "TagDefinitions"
         ],
+        "summary": "Returns a single tag definition. Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed. Allowed OData query options: Select",
         "description": "- Returns a single tag definition.\n- Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed.\n- Allowed OData query options: Select",
         "operationId": "GetTagDefinitionById",
         "parameters": [
@@ -4973,8 +5220,7 @@
               }
             }
           }
-        },
-        "summary": "Returns a single tag definition. Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed. Allowed OData query options: Select"
+        }
       }
     },
     "/v1/Repositories/{repoId}/TemplateDefinitions": {
@@ -4982,6 +5228,7 @@
         "tags": [
           "TemplateDefinitions"
         ],
+        "summary": "Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned. Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "description": "- Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned.\n- Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one.\n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetTemplateDefinitions",
         "parameters": [
@@ -5138,8 +5385,7 @@
               }
             }
           }
-        },
-        "summary": "Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned. Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one. Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       }
     },
     "/v1/Repositories/{repoId}/TemplateDefinitions/{templateId}": {
@@ -5147,6 +5393,7 @@
         "tags": [
           "TemplateDefinitions"
         ],
+        "summary": "Returns a single template definition (including field definitions, if relevant). Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed. Allowed OData query options: Select",
         "description": "- Returns a single template definition (including field definitions, if relevant).\n- Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed.\n- Allowed OData query options: Select",
         "operationId": "GetTemplateDefinitionById",
         "parameters": [
@@ -5254,8 +5501,7 @@
               }
             }
           }
-        },
-        "summary": "Returns a single template definition (including field definitions, if relevant). Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed. Allowed OData query options: Select"
+        }
       }
     },
     "/v1/Repositories/{repoId}/TemplateDefinitions/{templateId}/fields": {
@@ -5263,6 +5509,7 @@
         "tags": [
           "TemplateDefinitions"
         ],
+        "summary": "Returns the field definitions assigned to a template definition. Provide a template definition ID, and get a paged listing of the field definitions assigned to that template.  Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "description": "- Returns the field definitions assigned to a template definition.\n- Provide a template definition ID, and get a paged listing of the field definitions assigned to that template. \n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetTemplateFieldDefinitions",
         "parameters": [
@@ -5361,7 +5608,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Get field definitions successfully.",
+            "description": "Get template field definitions successfully.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5420,8 +5667,7 @@
               }
             }
           }
-        },
-        "summary": "Returns the field definitions assigned to a template definition. Provide a template definition ID, and get a paged listing of the field definitions assigned to that template.  Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       }
     },
     "/v1/Repositories/{repoId}/TemplateDefinitions/Fields": {
@@ -5429,6 +5675,7 @@
         "tags": [
           "TemplateDefinitions"
         ],
+        "summary": "Returns the field definitions assigned to a template definition. Provide a template definition name, and get a paged listing of the field definitions assigned to that template.  Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "description": "- Returns the field definitions assigned to a template definition.\n- Provide a template definition name, and get a paged listing of the field definitions assigned to that template. \n- Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.",
         "operationId": "GetTemplateFieldDefinitionsByTemplateName",
         "parameters": [
@@ -5527,7 +5774,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Get field definitions successfully.",
+            "description": "Get template field definitions successfully.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5586,8 +5833,7 @@
               }
             }
           }
-        },
-        "summary": "Returns the field definitions assigned to a template definition. Provide a template definition name, and get a paged listing of the field definitions assigned to that template.  Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer."
+        }
       }
     }
   },
@@ -5841,28 +6087,9 @@
           }
         }
       },
-      "LinkToUpdate": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "linkTypeId": {
-            "type": "integer",
-            "description": "The id of the link assigned to the entry.",
-            "format": "int32"
-          },
-          "otherSourceId": {
-            "type": "integer",
-            "description": "The id of the other source linked to the entry.",
-            "format": "int32"
-          },
-          "isSource": {
-            "type": "boolean",
-            "description": "Whether the entry is the source for the link."
-          }
-        }
-      },
       "FieldToUpdate": {
         "type": "object",
+        "description": "The request body containing fields that will be assigned to the entry.",
         "additionalProperties": false,
         "properties": {
           "values": {
@@ -5888,6 +6115,26 @@
             "type": "integer",
             "description": "The position of the value in the field. This is 1-indexed for multi value field. It will be ignored for single value field.",
             "format": "int32"
+          }
+        }
+      },
+      "LinkToUpdate": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "linkTypeId": {
+            "type": "integer",
+            "description": "The id of the link assigned to the entry.",
+            "format": "int32"
+          },
+          "otherSourceId": {
+            "type": "integer",
+            "description": "The id of the other source linked to the entry.",
+            "format": "int32"
+          },
+          "isSource": {
+            "type": "boolean",
+            "description": "Whether the entry is the source for the link."
           }
         }
       },
@@ -6178,6 +6425,68 @@
             "items": {
               "$ref": "#/components/schemas/WFieldInfo"
             }
+          }
+        }
+      },
+      "ODataValueContextOfIListOfEntryLinkTypeInfo": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ODataValueOfIListOfEntryLinkTypeInfo"
+          },
+          {
+            "type": "object",
+            "description": "A wrapper around the ODataValue with extra odata.nextLink and odata.count.",
+            "additionalProperties": false,
+            "properties": {
+              "@odata.nextLink": {
+                "type": "string",
+                "description": "It contains a URL that allows retrieving the next subset of the requested collection.",
+                "nullable": true
+              },
+              "@odata.count": {
+                "type": "integer",
+                "description": "It contains the count of a collection of entities or a collection of entity references.",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      },
+      "ODataValueOfIListOfEntryLinkTypeInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "value": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntryLinkTypeInfo"
+            }
+          }
+        }
+      },
+      "EntryLinkTypeInfo": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "linkTypeId": {
+            "type": "integer",
+            "description": "The ID of the entry link type.",
+            "format": "int32"
+          },
+          "sourceLabel": {
+            "type": "string",
+            "description": "The label for the source entry in the link type.",
+            "nullable": true
+          },
+          "targetLabel": {
+            "type": "string",
+            "description": "The label for the target entry in the link type.",
+            "nullable": true
+          },
+          "linkTypeDescription": {
+            "type": "string",
+            "description": "The description of the link type.",
+            "nullable": true
           }
         }
       },
@@ -6815,6 +7124,11 @@
             "description": "The description of the link type.",
             "nullable": true
           },
+          "linkTypeId": {
+            "type": "integer",
+            "description": "The ID of the entry link type.",
+            "format": "int32"
+          },
           "linkProperties": {
             "type": "object",
             "description": "The properties for the entry link.",
@@ -7041,25 +7355,49 @@
         "properties": {
           "operationToken": {
             "type": "string",
+            "description": "The operation token of the operation associated with this OperationProgress.",
             "nullable": true
           },
           "operationType": {
             "type": "string",
+            "description": "The type of the operation associated with this OperationProgress.",
             "nullable": true
           },
           "percentComplete": {
             "type": "integer",
+            "description": "Determines what percentage of the execution of the associated operation is completed.",
             "format": "int32"
           },
           "status": {
-            "$ref": "#/components/schemas/OperationStatus"
+            "description": "The status of the operation associated with this OperationProgress.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/OperationStatus"
+              }
+            ]
           },
           "errors": {
             "type": "array",
+            "description": "The list of errors occurred during the execution of the associated operation.",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/OperationErrorItem"
             }
+          },
+          "redirectUri": {
+            "type": "string",
+            "description": "The URI which can be used (via api call) to access the result(s) of the associated operation.",
+            "nullable": true
+          },
+          "startTimestamp": {
+            "type": "string",
+            "description": "The timestamp representing when the associated operation's execution is started.",
+            "format": "date-time"
+          },
+          "statusTimestamp": {
+            "type": "string",
+            "description": "The timestamp representing the last time when the associated task's status has changed.",
+            "format": "date-time"
           }
         }
       },
@@ -7087,10 +7425,12 @@
         "properties": {
           "objectId": {
             "type": "integer",
+            "description": "The ID of the entry to which the error is related. ",
             "format": "int32"
           },
           "errorMessage": {
             "type": "string",
+            "description": "The short description of the error.",
             "nullable": true
           }
         }

--- a/tests/integration/LinkDefinitions/GetLinkDefinitionByIdTest.cs
+++ b/tests/integration/LinkDefinitions/GetLinkDefinitionByIdTest.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.LinkDefinitions
+{
+    [TestClass]
+    public class GetLinkDefinitionByIdTest : BaseTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+        }
+
+        [TestMethod]
+        public async Task GetLinkDefinitionByIdAsync_ReturnLinkDefinition()
+        {
+            var allLinkDefinitionsResult = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId);
+            var firstLinkDefinition = allLinkDefinitionsResult.Value?.FirstOrDefault();
+            Assert.IsNotNull(firstLinkDefinition, "No link definitions exist in the repository.");
+
+            var linkDefinition = await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(RepositoryId, firstLinkDefinition.LinkTypeId);
+
+            Assert.IsNotNull(linkDefinition);
+            Assert.AreEqual(firstLinkDefinition.LinkTypeId, linkDefinition.LinkTypeId);
+        }
+    }
+}

--- a/tests/integration/LinkDefinitions/GetLinkDefinitionsTest.cs
+++ b/tests/integration/LinkDefinitions/GetLinkDefinitionsTest.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.LinkDefinitions
+{
+    [TestClass]
+    public class GetLinkDefinitionsTest : BaseTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+        }
+
+        [TestMethod]
+        public async Task GetLinkDefinitionsAsync_ReturnAllLinks()
+        {
+            var result = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId);
+            Assert.IsNotNull(result.Value);
+        }
+
+        [TestMethod]
+        public async Task GetLinkDefinitionsAsync_ForEachPaging()
+        {
+            int maxPageSize = 10;
+
+            Task<bool> PagingCallback(ODataValueContextOfIListOfEntryLinkTypeInfo data)
+            {
+                if (data.OdataNextLink != null)
+                {
+                    Assert.AreNotEqual(0, data.Value.Count);
+                    Assert.IsTrue(data.Value.Count <= maxPageSize);
+                    return Task.FromResult(true);
+                }
+                else
+                {
+                    return Task.FromResult(false);
+                }
+            }
+
+            await client.LinkDefinitionsClient.GetLinkDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
+            await Task.Delay(5000);
+        }
+
+        [TestMethod]
+        public async Task GetLinkDefinitionsAsync_SimplePaging()
+        {
+            int maxPageSize = 1;
+
+            // Initial request
+            var result = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            Assert.IsNotNull(result);
+
+            if (result.Value.Count == 0)
+            {
+                return; // There's no point testing if we don't have any such item.
+            }
+
+            var nextLink = result.OdataNextLink;
+            Assert.IsNotNull(nextLink);
+            Assert.IsTrue(result.Value.Count <= maxPageSize);
+
+            // Paging request
+            result = await client.LinkDefinitionsClient.GetLinkDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Value.Count <= maxPageSize);
+        }
+    }
+}

--- a/tests/unit/Entries/GetLinkValuesFromEntryAsyncTest.cs
+++ b/tests/unit/Entries/GetLinkValuesFromEntryAsyncTest.cs
@@ -32,6 +32,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 TargetFullPath = "targetFullPath",
                 TargetLabel = "targetLabel",
                 Description = "description",
+                LinkTypeId = 123,
                 LinkTypeDescription = "linkTypeDescription",
                 LinkProperties = new Dictionary<string, string>() { ["1"] = "2" },
                 SourceLink = "sourceLink",
@@ -48,6 +49,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 TargetFullPath = "targetFullPath2",
                 TargetLabel = "targetLabel2",
                 Description = "description2",
+                LinkTypeId = 456,
                 LinkTypeDescription = "linkTypeDescription2",
                 LinkProperties = new Dictionary<string, string>() { ["3"] = "4" },
                 SourceLink = "sourceLink2",
@@ -100,6 +102,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 Assert.Equal(links.ElementAt(i).TargetLabel, result.ElementAt(i).TargetLabel);
                 Assert.Equal(links.ElementAt(i).TargetLink, result.ElementAt(i).TargetLink);
                 Assert.Equal(links.ElementAt(i).Description, result.ElementAt(i).Description);
+                Assert.Equal(links.ElementAt(i).LinkTypeId, result.ElementAt(i).LinkTypeId);
                 Assert.Equal(links.ElementAt(i).LinkTypeDescription, result.ElementAt(i).LinkTypeDescription);
                 Assert.Equal(links.ElementAt(i).SourceLink, result.ElementAt(i).SourceLink);
                 foreach (var x in links.ElementAt(i).LinkProperties)
@@ -191,6 +194,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 TargetFullPath = "targetFullPath",
                 TargetLabel = "targetLabel",
                 Description = "description",
+                LinkTypeId = 123,
                 LinkTypeDescription = "linkTypeDescription",
                 LinkProperties = new Dictionary<string, string>() { ["1"] = "2" },
                 SourceLink = "sourceLink",
@@ -207,6 +211,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 TargetFullPath = "targetFullPath2",
                 TargetLabel = "targetLabel2",
                 Description = "description2",
+                LinkTypeId = 456,
                 LinkTypeDescription = "linkTypeDescription2",
                 LinkProperties = new Dictionary<string, string>() { ["3"] = "4" },
                 SourceLink = "sourceLink2",

--- a/tests/unit/Entries/SetLinkValuesOnEntryAsyncTest.cs
+++ b/tests/unit/Entries/SetLinkValuesOnEntryAsyncTest.cs
@@ -32,6 +32,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 TargetFullPath = "targetFullPath",
                 TargetLabel = "targetLabel",
                 Description = "description",
+                LinkTypeId = 123,
                 LinkTypeDescription = "linkTypeDescription",
                 LinkProperties = new Dictionary<string, string>() { ["1"] = "2" },
                 SourceLink = "sourceLink",
@@ -48,6 +49,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 TargetFullPath = "targetFullPath2",
                 TargetLabel = "targetLabel2",
                 Description = "description2",
+                LinkTypeId = 456,
                 LinkTypeDescription = "linkTypeDescription2",
                 LinkProperties = new Dictionary<string, string>() { ["3"] = "4" },
                 SourceLink = "sourceLink2",
@@ -114,6 +116,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 Assert.Equal(links.ElementAt(i).TargetLabel, result.ElementAt(i).TargetLabel);
                 Assert.Equal(links.ElementAt(i).TargetLink, result.ElementAt(i).TargetLink);
                 Assert.Equal(links.ElementAt(i).Description, result.ElementAt(i).Description);
+                Assert.Equal(links.ElementAt(i).LinkTypeId, result.ElementAt(i).LinkTypeId);
                 Assert.Equal(links.ElementAt(i).LinkTypeDescription, result.ElementAt(i).LinkTypeDescription);
                 Assert.Equal(links.ElementAt(i).SourceLink, result.ElementAt(i).SourceLink);
                 foreach (var x in links.ElementAt(i).LinkProperties)

--- a/tests/unit/LinkDefinitions/LinkDefinitionsByIdTest.cs
+++ b/tests/unit/LinkDefinitions/LinkDefinitionsByIdTest.cs
@@ -2,42 +2,30 @@
 using Moq.Protected;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
-namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
+namespace Laserfiche.Repository.Api.Client.Test.LinkDefinitions
 {
-    public class FieldDefinitionsByIdTest
+    public class LinkDefinitionsByIdTest
     {
         [Fact]
-        public async Task GetFieldDefinitionByIdAsync_200()
+        public async Task GetLinkDefinitionByIdAsync_200()
         {
             // ARRANGE
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             int id = 1;
 
-            WFieldInfo fieldInfo1 = new WFieldInfo()
+            EntryLinkTypeInfo linkType1 = new EntryLinkTypeInfo()
             {
-                Name = "name1",
-                Id = id,
-                Description = "description1",
-                FieldType = WFieldType.Blob,
-                Length = 100,
-                DefaultValue = "default1",
-                IsMultiValue = false,
-                IsRequired = false,
-                Constraint = "constraint1",
-                ConstraintError = "error1",
-                ListValues = new List<string>() { "value1" },
-                Format = WFieldFormat.Custom,
-                Currency = "currency1",
-                FormatPattern = "format1"
+                LinkTypeId = 1,
+                SourceLabel = "linktype sourcelabel",
+                TargetLabel = "linktype targetlabel",
+                LinkTypeDescription = "linktype description"
             };
 
             var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
@@ -53,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
                 .ReturnsAsync(new HttpResponseMessage()
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent(JsonConvert.SerializeObject(fieldInfo1))
+                    Content = new StringContent(JsonConvert.SerializeObject(linkType1))
                 })
                 .Verifiable();
 
@@ -67,24 +55,15 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(repoId, fieldDefinitionId: id);
-            Assert.Equal(fieldInfo1.Name, result.Name);
-            Assert.Equal(fieldInfo1.Id, result.Id);
-            Assert.Equal(fieldInfo1.Description, result.Description);
-            Assert.Equal(fieldInfo1.FieldType, result.FieldType);
-            Assert.Equal(fieldInfo1.DefaultValue, result.DefaultValue);
-            Assert.Equal(fieldInfo1.IsMultiValue, result.IsMultiValue);
-            Assert.Equal(fieldInfo1.IsRequired, result.IsRequired);
-            Assert.Equal(fieldInfo1.Constraint, result.Constraint);
-            Assert.Equal(fieldInfo1.ConstraintError, result.ConstraintError);
-            Assert.Equal(fieldInfo1.Format, result.Format);
-            Assert.Equal(fieldInfo1.Currency, result.Currency);
-            Assert.Equal(fieldInfo1.FormatPattern, result.FormatPattern);
-            Assert.Equal(fieldInfo1.ListValues.ElementAt(0), result.ListValues.ElementAt(0));
+            var result = await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(repoId, linkTypeId: id);
+            Assert.Equal(linkType1.LinkTypeId, result.LinkTypeId);
+            Assert.Equal(linkType1.SourceLabel, result.SourceLabel);
+            Assert.Equal(linkType1.TargetLabel, result.TargetLabel);
+            Assert.Equal(linkType1.LinkTypeDescription, result.LinkTypeDescription);
 
             // ASSERT
             // also check the 'http' call was like we expected it
-            var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/FieldDefinitions/{id}");
+            var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/LinkDefinitions/{id}");
 
             handlerMock.Protected().Verify(
                "SendAsync",
@@ -98,7 +77,7 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
         }
 
         [Fact]
-        public async Task GetFieldDefinitionByIdAsync_AnyOther()
+        public async Task GetLinkDefinitionByIdAsync_AnyOther()
         {
             // ARRANGE
             string baseAddress = "http://api.laserfiche.com/";
@@ -131,11 +110,11 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(repoId, fieldDefinitionId: id));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(repoId, linkTypeId: id));
 
             // ASSERT
             // also check the 'http' call was like we expected it
-            var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/FieldDefinitions/{id}");
+            var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/LinkDefinitions/{id}");
 
             handlerMock.Protected().Verify(
                "SendAsync",

--- a/tests/unit/LinkDefinitions/LinkDefinitionsTest.cs
+++ b/tests/unit/LinkDefinitions/LinkDefinitionsTest.cs
@@ -1,0 +1,216 @@
+﻿using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Laserfiche.Repository.Api.Client.Test.LinkDefinitions
+{
+    public class LinkDefinitionsTest
+    {
+        [Fact]
+        public async Task GetLinkDefinitionsAsync_200()
+        {
+            // ARRANGE
+            string baseAddress = "http://api.laserfiche.com/";
+            string repoId = "repoId";
+
+            EntryLinkTypeInfo linkType1 = new EntryLinkTypeInfo()
+            {
+                LinkTypeId = 1,
+                SourceLabel = "linktype sourcelabel 1",
+                TargetLabel = "linktype targetlabel 1",
+                LinkTypeDescription = "linktype description 1"
+            };
+            EntryLinkTypeInfo linkType2 = new EntryLinkTypeInfo()
+            {
+                LinkTypeId = 2,
+                SourceLabel = "linktype sourcelabel 2",
+                TargetLabel = "linktype targetlabel 2",
+                LinkTypeDescription = "linktype description 2"
+            };
+            ODataValueContextOfIListOfEntryLinkTypeInfo ret = new ODataValueContextOfIListOfEntryLinkTypeInfo()
+            {
+                Value = new List<EntryLinkTypeInfo>() { linkType1, linkType2 }
+            };
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+                // Setup the PROTECTED method to mock
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                // prepare the expected response of the mocked http call
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(JsonConvert.SerializeObject(ret))
+                })
+                .Verifiable();
+
+
+            // use real http client with mocked handler here
+            var httpClient = new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new Uri(baseAddress),
+            };
+
+            var client = new RepositoryApiClient(httpClient);
+
+            // ACT
+            var response = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId);
+            var result = response.Value;
+            Assert.Equal(2, result.Count);
+            for (int i = 0; i < 2; i++)
+            {
+                Assert.Equal(ret.Value.ElementAt(i).LinkTypeId, result.ElementAt(i).LinkTypeId);
+                Assert.Equal(ret.Value.ElementAt(i).SourceLabel, result.ElementAt(i).SourceLabel);
+                Assert.Equal(ret.Value.ElementAt(i).TargetLabel, result.ElementAt(i).TargetLabel);
+                Assert.Equal(ret.Value.ElementAt(i).LinkTypeDescription, result.ElementAt(i).LinkTypeDescription);
+            }
+
+            // ASSERT
+            // also check the 'http' call was like we expected it
+            var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/LinkDefinitions");
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+            Times.Exactly(1), // we expected a single external request
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Get  // we expected a GET request
+                  && req.RequestUri == expectedUri // to this uri
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [Fact]
+        public async Task GetLinkDefinitionsAsync_ODataQueryOptions()
+        {
+            // ARRANGE
+            string baseAddress = "http://api.laserfiche.com/";
+            string repoId = "repoId";
+
+            EntryLinkTypeInfo linkType1 = new EntryLinkTypeInfo()
+            {
+                LinkTypeId = 1,
+                SourceLabel = "linktype sourcelabel 1",
+                TargetLabel = "linktype targetlabel 1",
+                LinkTypeDescription = "linktype description 1"
+            };
+            EntryLinkTypeInfo linkType2 = new EntryLinkTypeInfo()
+            {
+                LinkTypeId = 2,
+                SourceLabel = "linktype sourcelabel 2",
+                TargetLabel = "linktype targetlabel 2",
+                LinkTypeDescription = "linktype description 2"
+            };
+            ODataValueContextOfIListOfEntryLinkTypeInfo ret = new ODataValueContextOfIListOfEntryLinkTypeInfo()
+            {
+                Value = new List<EntryLinkTypeInfo>() { linkType1, linkType2 }
+            };
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+                // Setup the PROTECTED method to mock
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                // prepare the expected response of the mocked http call
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.OK,
+                    Content = new StringContent(JsonConvert.SerializeObject(ret))
+                })
+                .Verifiable();
+
+
+            // use real http client with mocked handler here
+            var httpClient = new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new Uri(baseAddress),
+            };
+
+            var client = new RepositoryApiClient(httpClient);
+
+            // ACT
+            _ = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId, prefer: "Prefer", select: "select", orderby: "orderby", top: 1, skip: 2, count: true);
+
+            // ASSERT
+            // also check the 'http' call was like we expected it
+            var expectedUri = new Uri("http://api.laserfiche.com/v1/Repositories/repoId/LinkDefinitions?%24select=select&%24orderby=orderby&%24top=1&%24skip=2&%24count=true");
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+            Times.Exactly(1), // we expected a single external request
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Get  // we expected a GET request
+                  && req.RequestUri == expectedUri // to this uri
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+
+        [Fact]
+        public async Task GetLinkDefinitionsAsync_AnyOther()
+        {
+            // ARRANGE
+            string baseAddress = "http://api.laserfiche.com/";
+            string repoId = "repoId";
+
+            var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            handlerMock
+               .Protected()
+                // Setup the PROTECTED method to mock
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                // prepare the expected response of the mocked http call
+                .ReturnsAsync(new HttpResponseMessage()
+                {
+                    StatusCode = HttpStatusCode.InternalServerError
+                })
+                .Verifiable();
+
+
+            // use real http client with mocked handler here
+            var httpClient = new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new Uri(baseAddress),
+            };
+
+            var client = new RepositoryApiClient(httpClient);
+
+            // ACT
+            await Assert.ThrowsAsync<ApiException>(async () => await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId));
+
+            // ASSERT
+            // also check the 'http' call was like we expected it
+            var expectedUri = new Uri("http://api.laserfiche.com/v1/Repositories/repoId/LinkDefinitions");
+
+            handlerMock.Protected().Verify(
+               "SendAsync",
+            Times.Exactly(1), // we expected a single external request
+               ItExpr.Is<HttpRequestMessage>(req =>
+                  req.Method == HttpMethod.Get  // we expected a GET request
+                  && req.RequestUri == expectedUri // to this uri
+               ),
+               ItExpr.IsAny<CancellationToken>()
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Added LinkDefinition APIs
- Added LinkTypeId property to the WEntryLinkInfo class
- Added several properties to the OperationProgress class
- Minor documentation updates
- Update package version to 1.0.2
- add timeouts to steps in the workflow. These steps normally take less than a minute, so having the 10 min timeout should be more than enough. The default timeout is 2 hours https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes