### PR TITLE
update client lib with latest 2022.10 schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## 1.0.5
+
+### Fixes
+- Add missing `403` and `404` status codes to various APIs.
+- Add missing property `EntryId` to `OperationProgress` type.
+- Change `Entry` type to abstract. Should use the derived types like `Folder`, `Document`, `Shortcut`, and `RecordSeries`.
+- Deprecate the `ServerSession` APIs. This applies to the following:
+  - `ServerSessionClient.CreateServerSessionAsync`
+  - `ServerSessionClient.RefreshServerSessionAsync`
+  - `ServerSessionClient.InvalidateServerSessionAsync`

--- a/README.md
+++ b/README.md
@@ -16,3 +16,7 @@ Technically you could use any editors you like. But it's more convenient if you 
 ### Build, Test, and Package
 
 See the `./workflow/main.yml`.
+
+### Change Log
+
+See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/HEAD/CHANGELOG.md).

--- a/nswag.json
+++ b/nswag.json
@@ -17,6 +17,7 @@
       "operationGenerationMode": "MultipleClientsFromFirstTagAndOperationId",
       "generateClientInterfaces": true,
       "generateOptionalParameters": true,
+      "generateUpdateJsonSerializerSettingsMethod": false,
       "useBaseUrl": false,
       "clientClassAccessModifier": "internal",
       "templateDirectory": "nswag"

--- a/src/Clients/BaseClient.cs
+++ b/src/Clients/BaseClient.cs
@@ -10,6 +10,11 @@ namespace Laserfiche.Repository.Api.Client
 {
     internal class BaseClient
     {
+        protected void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings)
+        {
+            settings.MaxDepth = 128;
+        }
+
         protected async Task<T> GetNextLinkAsync<T>(HttpClient httpClient, string nextLink, string prefer, Func<HttpRequestMessage, HttpClient, bool[], CancellationToken, Task<T>> sendAndProcessResponseAsync, CancellationToken cancellationToken) where T : new()
         {
             if (nextLink == null)

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -31,7 +31,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="autoRename">An optional query parameter used to indicate if the new document should be automatically
         /// <br/>            renamed if an entry already exists with the given name in the folder. The default value is false.</param>
         /// <param name="culture">An optional query parameter used to indicate the locale that should be used.
-        /// <br/>            The value should be a standard language tag.</param>
+        /// <br/>            The value should be a standard language tag. This may be used when setting field values with tokens.</param>
         /// <returns>Document creation is success.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<CreateEntryResult> ImportDocumentAsync(string repoId, int parentEntryId, string fileName, bool? autoRename = null, string culture = null, FileParameter electronicDocument = null, PostEntryWithEdocMetadataRequest request = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -150,7 +150,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The entry ID of the entry that will have its fields updated.</param>
         /// <param name="culture">An optional query parameter used to indicate the locale that should be used.
-        /// <br/>            The value should be a standard language tag.</param>
+        /// <br/>            The value should be a standard language tag. This may be used when setting field values with tokens.</param>
         /// <returns>Update field values successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<ODataValueOfIListOfFieldValue> AssignFieldValuesAsync(string repoId, int entryId, System.Collections.Generic.IDictionary<string, FieldToUpdate> fieldsToUpdate = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -306,7 +306,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="entryId">The ID of entry that will have its template updated.</param>
         /// <param name="request">The template and template fields that will be assigned to the entry.</param>
         /// <param name="culture">An optional query parameter used to indicate the locale that should be used.
-        /// <br/>            The value should be a standard language tag.</param>
+        /// <br/>            The value should be a standard language tag. This may be used when setting field values with tokens.</param>
         /// <returns>Assign a template successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<Entry> WriteTemplateValueToEntryAsync(string repoId, int entryId, PutTemplateRequest request = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
@@ -350,7 +350,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="autoRename">An optional query parameter used to indicate if the new document should be automatically
         /// <br/>            renamed if an entry already exists with the given name in the folder. The default value is false.</param>
         /// <param name="culture">An optional query parameter used to indicate the locale that should be used.
-        /// <br/>            The value should be a standard language tag.</param>
+        /// <br/>            The value should be a standard language tag. This may be used when setting field values with tokens.</param>
         /// <returns>Document creation is success.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<CreateEntryResult> ImportDocumentAsync(string repoId, int parentEntryId, string fileName, bool? autoRename = null, string culture = null, FileParameter electronicDocument = null, PostEntryWithEdocMetadataRequest request = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -781,6 +781,16 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -1650,7 +1660,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="repoId">The requested repository ID.</param>
         /// <param name="entryId">The entry ID of the entry that will have its fields updated.</param>
         /// <param name="culture">An optional query parameter used to indicate the locale that should be used.
-        /// <br/>            The value should be a standard language tag.</param>
+        /// <br/>            The value should be a standard language tag. This may be used when setting field values with tokens.</param>
         /// <returns>Update field values successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<ODataValueOfIListOfFieldValue> AssignFieldValuesAsync(string repoId, int entryId, System.Collections.Generic.IDictionary<string, FieldToUpdate> fieldsToUpdate = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -2543,6 +2553,16 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -3609,7 +3629,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="entryId">The ID of entry that will have its template updated.</param>
         /// <param name="request">The template and template fields that will be assigned to the entry.</param>
         /// <param name="culture">An optional query parameter used to indicate the locale that should be used.
-        /// <br/>            The value should be a standard language tag.</param>
+        /// <br/>            The value should be a standard language tag. This may be used when setting field values with tokens.</param>
         /// <returns>Assign a template successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<Entry> WriteTemplateValueToEntryAsync(string repoId, int entryId, PutTemplateRequest request = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
@@ -4051,6 +4071,16 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -4663,6 +4693,16 @@ namespace Laserfiche.Repository.Api.Client
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -4973,6 +5013,16 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -5365,6 +5415,16 @@ namespace Laserfiche.Repository.Api.Client
                     throw new ApiException<ProblemDetails>("Access token is invalid or expired.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -5628,6 +5688,16 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -5958,6 +6028,16 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 if (status_ == 429)
@@ -6939,6 +7019,16 @@ namespace Laserfiche.Repository.Api.Client
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -7261,6 +7351,16 @@ namespace Laserfiche.Repository.Api.Client
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -7543,7 +7643,7 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         /// <param name="repoId">The requested repository ID</param>
         /// <param name="operationToken">The operation token</param>
-        /// <returns>Get completed operation status with no result successfully.</returns>
+        /// <returns>Get completed or failed operation status with no result successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         System.Threading.Tasks.Task<OperationProgress> GetOperationStatusAndProgressAsync(string repoId, string operationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
@@ -7592,7 +7692,7 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         /// <param name="repoId">The requested repository ID</param>
         /// <param name="operationToken">The operation token</param>
-        /// <returns>Get completed operation status with no result successfully.</returns>
+        /// <returns>Get completed or failed operation status with no result successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         public virtual async System.Threading.Tasks.Task<OperationProgress> GetOperationStatusAndProgressAsync(string repoId, string operationToken, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
@@ -8840,20 +8940,22 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Invalidates the server session. Acts as a "logout" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session. Only available in Laserfiche Cloud.
+        /// Deprecated. Invalidates the server session. Acts as a "logout" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session. Only available in Laserfiche Cloud.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <returns>Invalidate the server session successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        [System.Obsolete]
         System.Threading.Tasks.Task<ODataValueOfBoolean> InvalidateServerSessionAsync(string repoId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token. Only available in Laserfiche Cloud.
+        /// Deprecated. Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token. Only available in Laserfiche Cloud.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <returns>Refresh the session successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        [System.Obsolete]
         System.Threading.Tasks.Task<ODataValueOfDateTime> RefreshServerSessionAsync(string repoId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -8863,6 +8965,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="repoId">The requested repository ID.</param>
         /// <returns>Create the session successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        [System.Obsolete]
         System.Threading.Tasks.Task<ODataValueOfBoolean> CreateServerSessionAsync(string repoId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
     }
@@ -8896,11 +8999,12 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Invalidates the server session. Acts as a "logout" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session. Only available in Laserfiche Cloud.
+        /// Deprecated. Invalidates the server session. Acts as a "logout" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session. Only available in Laserfiche Cloud.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <returns>Invalidate the server session successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        [System.Obsolete]
         public virtual async System.Threading.Tasks.Task<ODataValueOfBoolean> InvalidateServerSessionAsync(string repoId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (repoId == null)
@@ -8993,6 +9097,16 @@ namespace Laserfiche.Repository.Api.Client
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -9017,11 +9131,12 @@ namespace Laserfiche.Repository.Api.Client
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
-        /// Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token. Only available in Laserfiche Cloud.
+        /// Deprecated. Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token. Only available in Laserfiche Cloud.
         /// </summary>
         /// <param name="repoId">The requested repository ID.</param>
         /// <returns>Refresh the session successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        [System.Obsolete]
         public virtual async System.Threading.Tasks.Task<ODataValueOfDateTime> RefreshServerSessionAsync(string repoId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (repoId == null)
@@ -9114,6 +9229,16 @@ namespace Laserfiche.Repository.Api.Client
                     throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Not found.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -9143,6 +9268,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="repoId">The requested repository ID.</param>
         /// <returns>Create the session successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
+        [System.Obsolete]
         public virtual async System.Threading.Tasks.Task<ODataValueOfBoolean> CreateServerSessionAsync(string repoId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (repoId == null)
@@ -9213,6 +9339,16 @@ namespace Laserfiche.Repository.Api.Client
                         throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
                     }
                     throw new ApiException<ProblemDetails>("Access token is invalid or expired.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw new ApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                    }
+                    throw new ApiException<ProblemDetails>("Access denied for the operation.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
                 }
                 else
                 {
@@ -9910,6 +10046,12 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("metadata", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PutFieldValsRequest Metadata { get; set; }
 
+        /// <summary>
+        /// The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("volumeName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string VolumeName { get; set; }
+
     }
 
     /// <summary>
@@ -10252,7 +10394,7 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class Entry
+    public abstract partial class Entry
     {
         /// <summary>
         /// The ID of the entry.
@@ -10422,6 +10564,12 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("hasMoreValues", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool HasMoreValues { get; set; }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class RecordSeries : Entry
+    {
 
     }
 
@@ -10988,6 +11136,12 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("sourceId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int SourceId { get; set; }
 
+        /// <summary>
+        /// The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("volumeName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string VolumeName { get; set; }
+
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
@@ -11016,6 +11170,12 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("sourceId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int SourceId { get; set; }
+
+        /// <summary>
+        /// The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("volumeName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string VolumeName { get; set; }
 
     }
 
@@ -11209,6 +11369,12 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("redirectUri", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string RedirectUri { get; set; }
+
+        /// <summary>
+        /// The ID of the entry affected (e.g. created or modified) by the execution of the associated operation.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("entryId", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int EntryId { get; set; }
 
         /// <summary>
         /// The timestamp representing when the associated operation's execution is started.

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -334,8 +334,6 @@ namespace Laserfiche.Repository.Api.Client
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
 
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
-
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
@@ -3934,8 +3932,6 @@ namespace Laserfiche.Repository.Api.Client
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
 
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
-
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
@@ -4405,8 +4401,6 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
-
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
 
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
@@ -4881,8 +4875,6 @@ namespace Laserfiche.Repository.Api.Client
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
 
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
-
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
@@ -5326,8 +5318,6 @@ namespace Laserfiche.Repository.Api.Client
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
 
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
-
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
@@ -5585,8 +5575,6 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
-
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
 
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
@@ -5921,8 +5909,6 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
-
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
 
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
@@ -6862,8 +6848,6 @@ namespace Laserfiche.Repository.Api.Client
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
 
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
-
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
@@ -7210,8 +7194,6 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
-
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
 
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
@@ -7679,8 +7661,6 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
-
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
 
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
@@ -8167,8 +8147,6 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
-
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
 
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
@@ -8990,8 +8968,6 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         protected Newtonsoft.Json.JsonSerializerSettings JsonSerializerSettings { get { return _settings.Value; } }
-
-        partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
 
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);

--- a/src/Clients/RepositoryClientsPartial.cs
+++ b/src/Clients/RepositoryClientsPartial.cs
@@ -22,6 +22,7 @@ namespace Laserfiche.Repository.Api.Client
     [JsonInheritance("Document", typeof(Document))]
     [JsonInheritance("Folder", typeof(Folder))]
     [JsonInheritance("Shortcut", typeof(Shortcut))]
+    [JsonInheritance("RecordSeries", typeof(RecordSeries))]
     partial class Entry
     { 
     }

--- a/src/Laserfiche.Repository.Api.Client.csproj
+++ b/src/Laserfiche.Repository.Api.Client.csproj
@@ -19,9 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Laserfiche.Api.Client.Core" Version="1.2.2-beta-3235788725" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Laserfiche.Api.Client.Core" Version="1.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Laserfiche.Repository.Api.Client.csproj
+++ b/src/Laserfiche.Repository.Api.Client.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Laserfiche.Api.Client.Core" Version="1.2.2-beta-3108861606" />
+    <PackageReference Include="Laserfiche.Api.Client.Core" Version="1.2.2-beta-3235788725" />
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="6.13.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/src/RepositoryApiClient.cs
+++ b/src/RepositoryApiClient.cs
@@ -108,7 +108,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="repoId"></param>
         /// <param name="username"></param>
         /// <param name="password"></param>
-        /// <param name="baseUrl">API server base URL e.g., https://example.com/LFRepositoryAPI/ </param>
+        /// <param name="baseUrl">API server base URL e.g., https://example.com/LFRepositoryAPI/</param>
         /// <returns></returns>
         public static IRepositoryApiClient CreateFromUsernamePassword(string repoId, string username, string password, string baseUrl)
         {

--- a/swagger.json
+++ b/swagger.json
@@ -64,7 +64,7 @@
           {
             "name": "culture",
             "in": "query",
-            "description": "An optional query parameter used to indicate the locale that should be used.\n            The value should be a standard language tag.",
+            "description": "An optional query parameter used to indicate the locale that should be used.\n            The value should be a standard language tag. This may be used when setting field values with tokens.",
             "schema": {
               "type": "string",
               "default": "",
@@ -297,6 +297,16 @@
           },
           "403": {
             "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -669,6 +679,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -795,6 +815,16 @@
           },
           "403": {
             "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1100,6 +1130,16 @@
           },
           "403": {
             "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1963,7 +2003,7 @@
           {
             "name": "culture",
             "in": "query",
-            "description": "An optional query parameter used to indicate the locale that should be used.\n            The value should be a standard language tag.",
+            "description": "An optional query parameter used to indicate the locale that should be used.\n            The value should be a standard language tag. This may be used when setting field values with tokens.",
             "schema": {
               "type": "string",
               "default": "",
@@ -2709,6 +2749,16 @@
           },
           "403": {
             "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3559,7 +3609,7 @@
           {
             "name": "culture",
             "in": "query",
-            "description": "An optional query parameter used to indicate the locale that should be used.\n            The value should be a standard language tag.",
+            "description": "An optional query parameter used to indicate the locale that should be used.\n            The value should be a standard language tag. This may be used when setting field values with tokens.",
             "schema": {
               "type": "string",
               "default": "",
@@ -3738,6 +3788,16 @@
               }
             }
           },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -3804,6 +3864,16 @@
           },
           "403": {
             "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -3918,6 +3988,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Operation limit or request limit reached.",
             "content": {
@@ -3983,7 +4063,7 @@
             }
           },
           "202": {
-            "description": "Search is still in progress.",
+            "description": "Search is still in progress or not started.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4663,6 +4743,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Operation limit or request limit reached.",
             "content": {
@@ -4800,6 +4890,16 @@
           },
           "403": {
             "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4969,7 +5069,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Get completed operation status with no result successfully.",
+            "description": "Get completed or failed operation status with no result successfully.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4989,7 +5089,7 @@
             }
           },
           "202": {
-            "description": "Get in progress operation status successfully.",
+            "description": "Get not started or in progress operation status successfully.",
             "content": {
               "application/json": {
                 "schema": {
@@ -5754,8 +5854,8 @@
         "tags": [
           "ServerSession"
         ],
-        "summary": "Invalidates the server session. Acts as a \"logout\" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session. Only available in Laserfiche Cloud.",
-        "description": "- Invalidates the server session.\n- Acts as a \"logout\" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.\n- Only available in Laserfiche Cloud.",
+        "summary": "Deprecated. Invalidates the server session. Acts as a \"logout\" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session. Only available in Laserfiche Cloud.",
+        "description": "- Deprecated.\n- Invalidates the server session.\n- Acts as a \"logout\" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.\n- Only available in Laserfiche Cloud.",
         "operationId": "InvalidateServerSession",
         "parameters": [
           {
@@ -5810,6 +5910,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -5820,7 +5930,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/v1/Repositories/{repoId}/ServerSession/Refresh": {
@@ -5828,8 +5939,8 @@
         "tags": [
           "ServerSession"
         ],
-        "summary": "Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token. Only available in Laserfiche Cloud.",
-        "description": "- Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires.\n- When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.\n- Only available in Laserfiche Cloud.",
+        "summary": "Deprecated. Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires. When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token. Only available in Laserfiche Cloud.",
+        "description": "- Deprecated.\n- Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires.\n- When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.\n- Only available in Laserfiche Cloud.",
         "operationId": "RefreshServerSession",
         "parameters": [
           {
@@ -5884,6 +5995,16 @@
               }
             }
           },
+          "404": {
+            "description": "Not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -5894,7 +6015,8 @@
               }
             }
           }
-        }
+        },
+        "deprecated": true
       }
     },
     "/v1/Repositories/{repoId}/ServerSession/Create": {
@@ -5937,8 +6059,19 @@
                 }
               }
             }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           }
-        }
+        },
+        "deprecated": true
       }
     }
   },
@@ -6609,6 +6742,11 @@
           },
           "metadata": {
             "$ref": "#/components/schemas/PutFieldValsRequest"
+          },
+          "volumeName": {
+            "type": "string",
+            "description": "The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.",
+            "nullable": true
           }
         }
       },
@@ -6952,6 +7090,7 @@
       },
       "Entry": {
         "type": "object",
+        "x-abstract": true,
         "additionalProperties": false,
         "properties": {
           "id": {
@@ -7109,6 +7248,17 @@
             "description": "A boolean indicating if there are more field values."
           }
         }
+      },
+      "RecordSeries": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Entry"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
       },
       "Document": {
         "allOf": [
@@ -7706,6 +7856,11 @@
             "type": "integer",
             "description": "The SourceId is needed for some operations that require a source/destination. One example is the Copy operation.",
             "format": "int32"
+          },
+          "volumeName": {
+            "type": "string",
+            "description": "The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.",
+            "nullable": true
           }
         }
       },
@@ -7733,6 +7888,11 @@
             "type": "integer",
             "description": "The source entry Id to copy.",
             "format": "int32"
+          },
+          "volumeName": {
+            "type": "string",
+            "description": "The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.",
+            "nullable": true
           }
         }
       },
@@ -7936,6 +8096,11 @@
             "type": "string",
             "description": "The URI which can be used (via api call) to access the result(s) of the associated operation.",
             "nullable": true
+          },
+          "entryId": {
+            "type": "integer",
+            "description": "The ID of the entry affected (e.g. created or modified) by the execution of the associated operation.",
+            "format": "int32"
           },
           "startTimestamp": {
             "type": "string",

--- a/tests/unit/Custom/LaserficheRepositoryApiClientCustomTest.cs
+++ b/tests/unit/Custom/LaserficheRepositoryApiClientCustomTest.cs
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Custom
             // ARRANGE
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
-            Entry entry = new Entry()
+            Entry entry = new Folder()
             {
                 Id = 10,
                 Name = "EntryName",
@@ -124,7 +124,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Custom
             string acceptLanguageHeaderValue = "fr-FR";
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
-            Entry entry = new Entry()
+            Entry entry = new Folder()
             {
                 Id = 10,
                 Name = "EntryName",

--- a/tests/unit/Entries/CreateCopyEntryTest.cs
+++ b/tests/unit/Entries/CreateCopyEntryTest.cs
@@ -23,7 +23,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = "entry1"
             };
-            var entry = new Entry()
+            var entry = new Folder()
             {
                 Id = 100,
                 Name = "entry1",
@@ -176,7 +176,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = "entry1"
             };
-            var entry = new Entry()
+            var entry = new Folder()
             {
                 Id = 100,
                 Name = "entry1",

--- a/tests/unit/Entries/DeleteAssignedTemplateAsyncTest.cs
+++ b/tests/unit/Entries/DeleteAssignedTemplateAsyncTest.cs
@@ -19,7 +19,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             var entryId = 1;
-            var entry = new Entry()
+            var entry = new Folder()
             {
                 Id = 1,
                 Name = "entry1",

--- a/tests/unit/Entries/GetEntryByFullPathTest.cs
+++ b/tests/unit/Entries/GetEntryByFullPathTest.cs
@@ -23,7 +23,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             bool fallBackToClosestAncestor = true;
             FindEntryResult getEntryByPath = new FindEntryResult()
             {
-                Entry = new Entry()
+                Entry = new Folder()
                 {
                     Id = 1,
                     Name = "EntryName",
@@ -111,7 +111,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             bool fallBackToClosestAncestor = true;
             FindEntryResult getAncestorEntryByPath = new FindEntryResult()
             {
-                AncestorEntry = new Entry()
+                AncestorEntry = new Folder()
                 {
                     Id = 1,
                     Name = "EntryName",

--- a/tests/unit/Entries/GetEntryInfoAsyncTest.cs
+++ b/tests/unit/Entries/GetEntryInfoAsyncTest.cs
@@ -18,7 +18,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             // ARRANGE
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
-            Entry entry = new Entry() { 
+            Entry entry = new Folder() { 
                 Id = 10, 
                 Name = "EntryName", 
                 ParentId = 1, 
@@ -152,7 +152,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             string selectQueryParameter = "name";
-            Entry entry = new Entry()
+            Entry entry = new Folder()
             {
                 Id = 10,
                 Name = "EntryName",

--- a/tests/unit/Entries/GetEntryListingTest.cs
+++ b/tests/unit/Entries/GetEntryListingTest.cs
@@ -25,7 +25,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             {
                 Value = new List<Entry>()
                 {
-                    new Entry()
+                    new Document()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new Entry()
+                    new Document()
                     {
                         Id = 101,
                         Name = "entry2",
@@ -198,7 +198,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             {
                 Value = new List<Entry>()
                 {
-                    new Entry()
+                    new Document()
                     {
                         Id = 100,
                         Name = "entry1",

--- a/tests/unit/Entries/MoveEntryTest.cs
+++ b/tests/unit/Entries/MoveEntryTest.cs
@@ -23,7 +23,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 ParentId = 10,
                 Name = "entry1"
             };
-            var entry = new Entry()
+            var entry = new Document()
             {
                 Id = 100,
                 Name = "entry1",
@@ -176,7 +176,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 ParentId = 10,
                 Name = "entry1"
             };
-            var entry = new Entry()
+            var entry = new Document()
             {
                 Id = 100,
                 Name = "entry1",

--- a/tests/unit/Entries/WriteTemplateValueToEntryAsyncTest.cs
+++ b/tests/unit/Entries/WriteTemplateValueToEntryAsyncTest.cs
@@ -21,7 +21,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             string baseAddress = "http://api.laserfiche.com/";
             string repoId = "repoId";
             var entryId = 1;
-            var entry = new Entry()
+            var entry = new Document()
             {
                 Id = 1,
                 Name = "entry1",

--- a/tests/unit/Searches/GetSearchResultsTest.cs
+++ b/tests/unit/Searches/GetSearchResultsTest.cs
@@ -25,7 +25,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             {
                 Value = new List<Entry>()
                 {
-                    new Entry()
+                    new Document()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new Entry()
+                    new Document()
                     {
                         Id = 101,
                         Name = "entry2",
@@ -199,7 +199,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             {
                 Value = new List<Entry>()
                 {
-                    new Entry()
+                    new Document()
                     {
                         Id = 100,
                         Name = "entry1",

--- a/tests/unit/SimpleSearches/SimpleSearchTest.cs
+++ b/tests/unit/SimpleSearches/SimpleSearchTest.cs
@@ -24,7 +24,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
             {
                 Value = new List<Entry>()
                 {
-                    new Entry()
+                    new Document()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -40,7 +40,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new Entry()
+                    new Document()
                     {
                         Id = 101,
                         Name = "entry2",
@@ -139,7 +139,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
             {
                 Value = new List<Entry>()
                 {
-                    new Entry()
+                    new Document()
                     {
                         Id = 100,
                         Name = "entry1",
@@ -155,7 +155,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
                         VolumeName = "default",
                         RowNumber = 1
                     },
-                    new Entry()
+                    new Document()
                     {
                         Id = 101,
                         Name = "entry2",


### PR DESCRIPTION
[GitHub Issue](https://github.com/Laserfiche/lf-repository-api-client-dotnet/issues/53)
- Update client library with latest schema for 2022.10
- Removed some dependency declarations since they are already part of `Laserfiche.Api.Client.Core`. Note that this includes lowering the `Newtonsoft.Json` version to v12.0.3. By lowering the version, I apply the MaxDepth fix mentioned in this post https://github.com/advisories/GHSA-5crp-9r3c-p9vr
- Add a changelog. See the additions to the changelog for what else was changed

