### PR TITLE
Rename method name from MoveOrRenameDocument to MoveOrRenameEntry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.6
+
+### Fixes
+- **[BREAKING]**: `IEntriesClient`
+  - Rename `MoveOrRenameDocumentAsync` to `MoveOrRenameEntryAsync` to better represent its capability.
+
 ## 1.0.5
 
 ### Fixes

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -72,7 +72,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <br/>            The value should be a standard language tag.</param>
         /// <returns>Moves and/or renames an entry successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<Entry> MoveOrRenameDocumentAsync(string repoId, int entryId, PatchEntryRequest request = null, bool? autoRename = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<Entry> MoveOrRenameEntryAsync(string repoId, int entryId, PatchEntryRequest request = null, bool? autoRename = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -827,7 +827,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <br/>            The value should be a standard language tag.</param>
         /// <returns>Moves and/or renames an entry successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<Entry> MoveOrRenameDocumentAsync(string repoId, int entryId, PatchEntryRequest request = null, bool? autoRename = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Entry> MoveOrRenameEntryAsync(string repoId, int entryId, PatchEntryRequest request = null, bool? autoRename = null, string culture = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (repoId == null)
                 throw new System.ArgumentNullException("repoId");
@@ -868,7 +868,7 @@ namespace Laserfiche.Repository.Api.Client
 
                     PrepareRequest(client_, request_, url_);
 
-                    return await MoveOrRenameDocumentSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return await MoveOrRenameEntrySendAsync(request_, client_, disposeClient_, cancellationToken);
                 }
             }
             finally
@@ -878,7 +878,7 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
-        public virtual async System.Threading.Tasks.Task<Entry> MoveOrRenameDocumentSendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<Entry> MoveOrRenameEntrySendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             var disposeResponse_ = true;

--- a/tests/integration/Entries/MoveEntryTest.cs
+++ b/tests/integration/Entries/MoveEntryTest.cs
@@ -42,7 +42,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = "RepositoryApiClientIntegrationTest .Net MovedFolder"
             };
 
-            var movedEntry = await client.EntriesClient.MoveOrRenameDocumentAsync(RepositoryId, childFolder.Id, request, autoRename: true);
+            var movedEntry = await client.EntriesClient.MoveOrRenameEntryAsync(RepositoryId, childFolder.Id, request, autoRename: true);
 
             Assert.IsNotNull(movedEntry);
             Assert.AreEqual(childFolder.Id, movedEntry.Id);

--- a/tests/unit/Entries/MoveEntryTest.cs
+++ b/tests/unit/Entries/MoveEntryTest.cs
@@ -13,7 +13,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
     public class MoveEntryTest
     {
         [Fact]
-        public async Task MoveOrRenameDocumentAsync_ReturnSuccessfulStatusCode()
+        public async Task MoveOrRenameEntryAsync_ReturnSuccessfulStatusCode()
         {
             // ARRANGE
             string baseAddress = "http://api.laserfiche.com/";
@@ -69,7 +69,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.MoveOrRenameDocumentAsync(repoId, entry.Id, request);
+            var result = await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entry.Id, request);
 
             // ASSERT
             Assert.NotNull(result);
@@ -104,7 +104,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
         }
 
         [Fact]
-        public async Task MoveOrRenameDocumentAsync_ReturnErrorStatusCode()
+        public async Task MoveOrRenameEntryAsync_ReturnErrorStatusCode()
         {
             // ARRANGE
             string baseAddress = "http://api.laserfiche.com/";
@@ -145,7 +145,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.MoveOrRenameDocumentAsync(repoId, entryId, request));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entryId, request));
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -166,7 +166,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
         }
 
         [Fact]
-        public async Task MoveOrRenameDocumentAsync_WithQueryParameter_ReturnSuccessfulStatusCode()
+        public async Task MoveOrRenameEntryAsync_WithQueryParameter_ReturnSuccessfulStatusCode()
         {
             // ARRANGE
             string baseAddress = "http://api.laserfiche.com/";
@@ -222,7 +222,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.MoveOrRenameDocumentAsync(repoId, entry.Id, request, autoRename: true);
+            var result = await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entry.Id, request, autoRename: true);
 
             // ASSERT
             Assert.NotNull(result);


### PR DESCRIPTION
The `MoveOrRenameDocument` API can also be applied to other types of entries, not just `Document`. So in this PR, we changed its name to `MoveOrRenameEntry` to better reflect its capability.