### PR TITLE
fix EntriesClient.GetDocumentContentTypeAsync to return headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Prerelease
+
+### Fixes
+- **[BREAKING]**: `IEntriesClient`
+  - Fix `GetDocumentContentTypeAsync` return type from `Task` to `Task<HttpResponseHead>` to allow retrieving response headers.
+
 ## 1.0.5
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## Prerelease
 
 ### Fixes
-- **[BREAKING]**: `IEntriesClient`
-  - Fix `GetDocumentContentTypeAsync` return type from `Task` to `Task<HttpResponseHead>` to allow retrieving response headers.
+- Fix `IEntriesClient.GetDocumentContentTypeAsync` return type from `Task` to `Task<HttpResponseHead>` to allow retrieving response headers.
 
 ## 1.0.5
 

--- a/nswag.json
+++ b/nswag.json
@@ -20,7 +20,9 @@
       "generateUpdateJsonSerializerSettingsMethod": false,
       "useBaseUrl": false,
       "clientClassAccessModifier": "internal",
-      "templateDirectory": "nswag"
+      "templateDirectory": "nswag",
+      "wrapResponses": true,
+      "wrapResponseMethods": ["EntriesClient.GetDocumentContentType"]
     }
   }
 }

--- a/nswag.json
+++ b/nswag.json
@@ -22,7 +22,8 @@
       "clientClassAccessModifier": "internal",
       "templateDirectory": "nswag",
       "wrapResponses": true,
-      "wrapResponseMethods": ["EntriesClient.GetDocumentContentType"]
+      "wrapResponseMethods": ["EntriesClient.GetDocumentContentType"],
+      "responseClass": "HttpResponseHead"
     }
   }
 }

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -241,7 +241,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="entryId">The requested document ID.</param>
         /// <returns>Get edoc info successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task<SwaggerResponse> GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<HttpResponseHead> GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -2738,7 +2738,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="entryId">The requested document ID.</param>
         /// <returns>Get edoc info successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task<SwaggerResponse> GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<HttpResponseHead> GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (repoId == null)
                 throw new System.ArgumentNullException("repoId");
@@ -2776,7 +2776,7 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
-        public virtual async System.Threading.Tasks.Task<SwaggerResponse> GetDocumentContentTypeSendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<HttpResponseHead> GetDocumentContentTypeSendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             var disposeResponse_ = true;
@@ -2794,7 +2794,7 @@ namespace Laserfiche.Repository.Api.Client
                 var status_ = (int)response_.StatusCode;
                 if (status_ == 200)
                 {
-                    return new SwaggerResponse(status_, headers_);
+                    return new HttpResponseHead(status_, headers_);
                 }
                 else
                 if (status_ == 400)
@@ -11813,13 +11813,13 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class SwaggerResponse
+    public partial class HttpResponseHead
     {
         public int StatusCode { get; private set; }
 
         public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
 
-        public SwaggerResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers)
+        public HttpResponseHead(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers)
         {
             StatusCode = statusCode;
             Headers = headers;
@@ -11827,11 +11827,11 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
-    public partial class SwaggerResponse<TResult> : SwaggerResponse
+    public partial class HttpResponseHead<TResult> : HttpResponseHead
     {
         public TResult Result { get; private set; }
 
-        public SwaggerResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result)
+        public HttpResponseHead(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result)
             : base(statusCode, headers)
         {
             Result = result;

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -241,7 +241,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="entryId">The requested document ID.</param>
         /// <returns>Get edoc info successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        System.Threading.Tasks.Task GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<SwaggerResponse> GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
         /// <summary>
@@ -2738,7 +2738,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <param name="entryId">The requested document ID.</param>
         /// <returns>Get edoc info successfully.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
-        public virtual async System.Threading.Tasks.Task GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<SwaggerResponse> GetDocumentContentTypeAsync(string repoId, int entryId, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             if (repoId == null)
                 throw new System.ArgumentNullException("repoId");
@@ -2766,8 +2766,7 @@ namespace Laserfiche.Repository.Api.Client
 
                     PrepareRequest(client_, request_, url_);
 
-                    await GetDocumentContentTypeSendAsync(request_, client_, disposeClient_, cancellationToken);
-                    return;
+                    return await GetDocumentContentTypeSendAsync(request_, client_, disposeClient_, cancellationToken);
                 }
             }
             finally
@@ -2777,7 +2776,7 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
-        public virtual async System.Threading.Tasks.Task GetDocumentContentTypeSendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public virtual async System.Threading.Tasks.Task<SwaggerResponse> GetDocumentContentTypeSendAsync(System.Net.Http.HttpRequestMessage request_, System.Net.Http.HttpClient client_, bool[] disposeClient_, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             var disposeResponse_ = true;
@@ -2795,7 +2794,7 @@ namespace Laserfiche.Repository.Api.Client
                 var status_ = (int)response_.StatusCode;
                 if (status_ == 200)
                 {
-                    return;
+                    return new SwaggerResponse(status_, headers_);
                 }
                 else
                 if (status_ == 400)
@@ -11810,6 +11809,32 @@ namespace Laserfiche.Repository.Api.Client
                 _response.Dispose();
             if (_client != null)
                 _client.Dispose();
+        }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class SwaggerResponse
+    {
+        public int StatusCode { get; private set; }
+
+        public System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
+
+        public SwaggerResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers)
+        {
+            StatusCode = statusCode;
+            Headers = headers;
+        }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "13.15.10.0 (NJsonSchema v10.6.10.0 (Newtonsoft.Json v11.0.0.0))")]
+    public partial class SwaggerResponse<TResult> : SwaggerResponse
+    {
+        public TResult Result { get; private set; }
+
+        public SwaggerResponse(int statusCode, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result)
+            : base(statusCode, headers)
+        {
+            Result = result;
         }
     }
 

--- a/tests/integration/Entries/GetDocumentContentTypeTest.cs
+++ b/tests/integration/Entries/GetDocumentContentTypeTest.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
+{
+    [TestClass]
+    public class GetDocumentContentTypeTest : BaseTest
+    {
+        int createdEntryId;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+            createdEntryId = 0;
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            if (createdEntryId != 0)
+            {
+                DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetDocumentContentTypeAsync_ReturnHeaders()
+        {
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContentTypeAsync");
+
+            var response = await client.EntriesClient.GetDocumentContentTypeAsync(RepositoryId, createdEntryId);
+
+            Assert.AreEqual(200, response.StatusCode);
+            Assert.IsTrue(response.Headers.ContainsKey("Content-Type"));
+            Assert.IsTrue(response.Headers.ContainsKey("Content-Length"));
+        }
+    }
+}

--- a/tests/integration/Entries/GetEdocTest.cs
+++ b/tests/integration/Entries/GetEdocTest.cs
@@ -35,7 +35,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task GetEdoc_ReturnDocument()
         {
-            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net ExportDocumentAsync");
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContent");
 
             using (var response = await client.EntriesClient.ExportDocumentAsync(RepositoryId, createdEntryId))
             {

--- a/tests/integration/Entries/GetEdocTest.cs
+++ b/tests/integration/Entries/GetEdocTest.cs
@@ -32,31 +32,10 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
         }
 
-        private async Task<int> CreateDocument()
-        {
-            int parentEntryId = 1;
-            string fileName = "RepositoryApiClientIntegrationTest .Net GetDocumentContent";
-            string fileLocation = TempPath + "test.pdf";
-            var request = new PostEntryWithEdocMetadataRequest();
-            using (var fileStream = File.OpenRead(fileLocation))
-            {
-                var electronicDocument = new FileParameter(fileStream, "test", "application/pdf");
-                var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request);
-
-                var operations = result.Operations;
-                Assert.IsNotNull(operations?.EntryCreate);
-                Assert.AreEqual(0, operations.EntryCreate.Exceptions.Count);
-                Assert.AreNotEqual(0, operations.EntryCreate.EntryId);
-                Assert.AreEqual(0, operations.SetEdoc.Exceptions.Count);
-                Assert.IsFalse(string.IsNullOrEmpty(result.DocumentLink));
-                return operations.EntryCreate.EntryId;
-            }
-        }
-
         [TestMethod]
         public async Task GetEdoc_ReturnDocument()
         {
-            createdEntryId = await CreateDocument();
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net ExportDocumentAsync");
 
             using (var response = await client.EntriesClient.ExportDocumentAsync(RepositoryId, createdEntryId))
             {

--- a/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
+++ b/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
@@ -35,7 +35,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task Export_document_with_audit_reasonAsync_ReturnDocument()
         {
-            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net ExportDocumentWithAuditReasonAsync");
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContent AuditReason");
             var request = new GetEdocWithAuditReasonRequest();
 
             using (var response = await client.EntriesClient.ExportDocumentWithAuditReasonAsync(RepositoryId, createdEntryId, request))

--- a/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
+++ b/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
@@ -32,31 +32,10 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             }
         }
 
-        private async Task<int> CreateDocument()
-        {
-            int parentEntryId = 1;
-            string fileName = "RepositoryApiClientIntegrationTest .Net GetDocumentContent AuditReason";
-            string fileLocation = TempPath + "test.pdf";
-            var request = new PostEntryWithEdocMetadataRequest();
-            using (var fileStream = File.OpenRead(fileLocation))
-            {
-                var electronicDocument = new FileParameter(fileStream, "test", "application/pdf");
-                var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request);
-
-                var operations = result.Operations;
-                Assert.IsNotNull(operations?.EntryCreate);
-                Assert.AreEqual(0, operations.EntryCreate.Exceptions.Count);
-                Assert.AreNotEqual(0, operations.EntryCreate.EntryId);
-                Assert.AreEqual(0, operations.SetEdoc.Exceptions.Count);
-                Assert.IsFalse(string.IsNullOrEmpty(result.DocumentLink));
-                return operations.EntryCreate.EntryId;
-            }
-        }
-
         [TestMethod]
         public async Task Export_document_with_audit_reasonAsync_ReturnDocument()
         {
-            createdEntryId = await CreateDocument();
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net ExportDocumentWithAuditReasonAsync");
             var request = new GetEdocWithAuditReasonRequest();
 
             using (var response = await client.EntriesClient.ExportDocumentWithAuditReasonAsync(RepositoryId, createdEntryId, request))

--- a/tests/unit/Entries/GetDocumentContentTypeAsyncTest.cs
+++ b/tests/unit/Entries/GetDocumentContentTypeAsyncTest.cs
@@ -2,6 +2,7 @@
 using Moq.Protected;
 using Newtonsoft.Json;
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -51,7 +52,13 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await client.EntriesClient.GetDocumentContentTypeAsync(repoId, entryId);
+            var swaggerResponse = await client.EntriesClient.GetDocumentContentTypeAsync(repoId, entryId);
+
+            // ASSERT
+            Assert.NotNull(swaggerResponse);
+            Assert.Equal(200, swaggerResponse.StatusCode);
+            Assert.Equal(httpResponse.Content.Headers.ContentType.ToString(), swaggerResponse.Headers["Content-Type"].ElementAt(0).ToString());
+            Assert.Equal(httpResponse.Content.Headers.ContentLength.ToString(), swaggerResponse.Headers["Content-Length"].ElementAt(0).ToString());
 
             // Also check the 'http' call was like we expected it
             var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc");


### PR DESCRIPTION
Pull request to resolve Issue https://github.com/Laserfiche/lf-repository-api-client-dotnet/issues/56