### PR TITLE
changed authorizationtype enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 - Added `RepositoriesClient.GetSelfHostedRepositoryListAsync` method that will enable self hosted users to get their repository list without an access token.
-- Changed `AuthorizationType` enums from `CloudAccessKey` and `APIServerUsernamePassword` to `CLOUD_ACCESS_KEY` and `API_SERVER_USERNAME_PASSWORD` respecitvely.
+- Changed `AuthorizationType` enum values from `CloudAccessKey` and `APIServerUsernamePassword` to `CLOUD_ACCESS_KEY` and `API_SERVER_USERNAME_PASSWORD` respecitvely.
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 - Added `RepositoriesClient.GetSelfHostedRepositoryListAsync` method that will enable self hosted users to get their repository list without an access token.
+- Changed `AuthorizationType` enums from `CloudAccessKey` and `APIServerUsernamePassword` to `CLOUD_ACCESS_KEY` and `API_SERVER_USERNAME_PASSWORD` respecitvely.
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Features
 - Added `RepositoriesClient.GetSelfHostedRepositoryListAsync` method that will enable self hosted users to get their repository list without an access token.
-- Changed `AuthorizationType` enum values from `CloudAccessKey` and `APIServerUsernamePassword` to `CLOUD_ACCESS_KEY` and `API_SERVER_USERNAME_PASSWORD` respecitvely.
 
 ## 1.1.1
 

--- a/tests/integration/AccessTokens/InvalidateServerSessionTest.cs
+++ b/tests/integration/AccessTokens/InvalidateServerSessionTest.cs
@@ -15,7 +15,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.AccessTokens
         [TestMethod]
         public async Task InvalidateServerSession_LogoutSuccessful()
         {
-            if (AuthorizationType == AuthorizationType.APIServerUsernamePassword)
+            if (AuthorizationType == AuthorizationType.API_SERVER_USERNAME_PASSWORD)
             {
                 return;
             }

--- a/tests/integration/AccessTokens/RefreshServerSessionTest.cs
+++ b/tests/integration/AccessTokens/RefreshServerSessionTest.cs
@@ -16,7 +16,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.AccessTokens
         [TestMethod]
         public async Task RefreshServerSession_RefreshSuccessful()
         {
-            if (AuthorizationType == AuthorizationType.APIServerUsernamePassword)
+            if (AuthorizationType == AuthorizationType.API_SERVER_USERNAME_PASSWORD)
             {
                 return;
             }

--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -10,8 +10,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
 {
     public enum AuthorizationType
     {
-        CloudAccessKey,
-        APIServerUsernamePassword
+        CLOUD_ACCESS_KEY,
+        API_SERVER_USERNAME_PASSWORD
     }
 
     public class BaseTest
@@ -81,13 +81,13 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
         {
             if (client == null)
             {
-                if (AuthorizationType == AuthorizationType.CloudAccessKey)
+                if (AuthorizationType == AuthorizationType.CLOUD_ACCESS_KEY)
                 {
                     if (string.IsNullOrEmpty(ServicePrincipalKey) || AccessKey == null)
                         return null;
                     client = RepositoryApiClient.CreateFromAccessKey(ServicePrincipalKey, AccessKey);
                 }
-                else if (AuthorizationType == AuthorizationType.APIServerUsernamePassword)
+                else if (AuthorizationType == AuthorizationType.API_SERVER_USERNAME_PASSWORD)
                 {
                     if (string.IsNullOrEmpty(RepositoryId) || string.IsNullOrEmpty(Username) || string.IsNullOrEmpty(Password) || string.IsNullOrEmpty(BaseUrl))
                         return null;

--- a/tests/integration/Repositories/GetRepositoryListTest.cs
+++ b/tests/integration/Repositories/GetRepositoryListTest.cs
@@ -22,7 +22,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Repositories
             foreach (var repoInfo in result)
             {
                 Assert.IsFalse(string.IsNullOrEmpty(repoInfo.RepoId));
-                if (AuthorizationType != AuthorizationType.APIServerUsernamePassword)
+                if (AuthorizationType != AuthorizationType.API_SERVER_USERNAME_PASSWORD)
                 {
                     Assert.IsFalse(string.IsNullOrEmpty(repoInfo.WebclientUrl));
                     Assert.IsTrue(repoInfo.WebclientUrl.Contains(repoInfo.RepoId));
@@ -37,7 +37,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Repositories
         [TestMethod]
         public async Task GetSelfHostedRepositoryList_ReturnSuccessful()
         {
-            if (AuthorizationType == AuthorizationType.CloudAccessKey)
+            if (AuthorizationType == AuthorizationType.CLOUD_ACCESS_KEY)
             {
                 return; // There's no point testing if it is a cloud environment
             }

--- a/tests/integration/RepositoryApiClientTest.cs
+++ b/tests/integration/RepositoryApiClientTest.cs
@@ -20,10 +20,10 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
             IRepositoryApiClient invalidClient;
             switch (AuthorizationType)
             {
-                case AuthorizationType.CloudAccessKey:
+                case AuthorizationType.CLOUD_ACCESS_KEY:
                     invalidClient = RepositoryApiClient.CreateFromAccessKey("a wrong service principal key", AccessKey);
                     break;
-                case AuthorizationType.APIServerUsernamePassword:
+                case AuthorizationType.API_SERVER_USERNAME_PASSWORD:
                     invalidClient = RepositoryApiClient.CreateFromUsernamePassword(RepositoryId, Username, "wrong_password", BaseUrl);
                     break;
                 default:


### PR DESCRIPTION
- changed authorization type enums
   - changed `CloudAccessKey` to `CLOUD_ACCESS_KEY`
   - changed `APIServerUsernamePassword` to `API_SERVER_USERNAME_PASSWORD`
- updated integration tests
- updated secret (will need to get permission to update org secret for APIserver secret afterwards)
- updated changelog