### PR TITLE
Task/420779 configure await

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,91 @@
+[*.{cs,vb}]
+dotnet_diagnostic.CA2007.severity = error
+dotnet_code_quality.CA2007.exclude_async_void_methods = true
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+
+[*.cs]
+csharp_indent_labels = one_less_than_current
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion

--- a/Laserfiche.Repository.Api.Client.sln
+++ b/Laserfiche.Repository.Api.Client.sln
@@ -1,13 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31112.23
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33424.131
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Laserfiche.Repository.Api.Client", "src\Laserfiche.Repository.Api.Client.csproj", "{92C448D6-C50E-45FF-8C6D-E25FDBD65EB0}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Laserfiche.Repository.Api.Client.Test", "tests\unit\Laserfiche.Repository.Api.Client.Test.csproj", "{1F63932D-3248-4A9A-ADC1-9A8A16F75440}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Laserfiche.Repository.Api.Client.IntegrationTest", "tests\integration\Laserfiche.Repository.Api.Client.IntegrationTest.csproj", "{32DE1419-B73E-4D3F-960E-EF13F32F05D6}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{820A4706-DE2D-4F9E-8760-AD027DC8304A}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Clients/AttributesClient.cs
+++ b/src/Clients/AttributesClient.cs
@@ -43,18 +43,18 @@ namespace Laserfiche.Repository.Api.Client
         public async Task GetTrusteeAttributeKeyValuePairsForEachAsync(Func<ODataValueContextOfListOfAttribute, Task<bool>> callback, string repoId, bool? everyone = null, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetTrusteeAttributeKeyValuePairsAsync(repoId, everyone, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken);
+            var response = await GetTrusteeAttributeKeyValuePairsAsync(repoId, everyone, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTrusteeAttributeKeyValuePairsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTrusteeAttributeKeyValuePairsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ODataValueContextOfListOfAttribute> GetTrusteeAttributeKeyValuePairsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTrusteeAttributeKeyValuePairsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTrusteeAttributeKeyValuePairsSendAsync, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Clients/BaseClient.cs
+++ b/src/Clients/BaseClient.cs
@@ -33,7 +33,7 @@ namespace Laserfiche.Repository.Api.Client
                     }
                     request.RequestUri = new Uri(nextLink, UriKind.Absolute);
 
-                    var response = await sendAndProcessResponseAsync(request, httpClient, new bool[] { false }, cancellationToken);
+                    var response = await sendAndProcessResponseAsync(request, httpClient, new bool[] { false }, cancellationToken).ConfigureAwait(false);
                     return response;
                 }
             }

--- a/src/Clients/EntriesClient.cs
+++ b/src/Clients/EntriesClient.cs
@@ -149,76 +149,76 @@ namespace Laserfiche.Repository.Api.Client
                 request.Method = new HttpMethod("GET");
                 request.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
                 request.RequestUri = new Uri(uriString, UriKind.Absolute);
-                return await GetEntrySendAsync(request, _httpClient, new bool[] { false }, cancellationToken);
+                return await GetEntrySendAsync(request, _httpClient, new bool[] { false }, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task GetEntryListingForEachAsync(Func<ODataValueContextOfIListOfEntry, Task<bool>> callback, string repoId, int entryId, bool? groupByEntryType = null, IEnumerable<string> fields = null, bool? formatFields = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetEntryListingAsync(repoId, entryId, groupByEntryType, fields, formatFields, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);
+            var response = await GetEntryListingAsync(repoId, entryId, groupByEntryType, fields, formatFields, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetEntryListingSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetEntryListingSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task GetFieldValuesForEachAsync(Func<ODataValueContextOfIListOfFieldValue, Task<bool>> callback, string repoId, int entryId, string prefer = null, bool? formatValue = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetFieldValuesAsync(repoId, entryId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), formatValue, culture, select, orderby, top, skip, count, cancellationToken);
+            var response = await GetFieldValuesAsync(repoId, entryId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), formatValue, culture, select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetFieldValuesSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetFieldValuesSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task GetLinkValuesFromEntryForEachAsync(Func<ODataValueContextOfIListOfWEntryLinkInfo, Task<bool>> callback, string repoId, int entryId, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetLinkValuesFromEntryAsync(repoId, entryId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken);
+            var response = await GetLinkValuesFromEntryAsync(repoId, entryId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetLinkValuesFromEntrySendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetLinkValuesFromEntrySendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task GetTagsAssignedToEntryForEachAsync(Func<ODataValueContextOfIListOfWTagInfo, Task<bool>> callback, string repoId, int entryId, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetTagsAssignedToEntryAsync(repoId, entryId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken);
+            var response = await GetTagsAssignedToEntryAsync(repoId, entryId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTagsAssignedToEntrySendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTagsAssignedToEntrySendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ODataValueContextOfIListOfEntry> GetEntryListingNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetEntryListingSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetEntryListingSendAsync, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ODataValueContextOfIListOfFieldValue> GetFieldValuesNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldValuesSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldValuesSendAsync, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ODataValueContextOfIListOfWEntryLinkInfo> GetLinkValuesFromEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetLinkValuesFromEntrySendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetLinkValuesFromEntrySendAsync, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ODataValueContextOfIListOfWTagInfo> GetTagsAssignedToEntryNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagsAssignedToEntrySendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagsAssignedToEntrySendAsync, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Clients/FieldDefinitionsClient.cs
+++ b/src/Clients/FieldDefinitionsClient.cs
@@ -45,18 +45,18 @@ namespace Laserfiche.Repository.Api.Client
         public async Task GetFieldDefinitionsForEachAsync(Func<ODataValueContextOfIListOfWFieldInfo, Task<bool>> callback, string repoId, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetFieldDefinitionsAsync(repoId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);
+            var response = await GetFieldDefinitionsAsync(repoId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetFieldDefinitionsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetFieldDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ODataValueContextOfIListOfWFieldInfo> GetFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldDefinitionsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetFieldDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Clients/LinkDefinitionsClient.cs
+++ b/src/Clients/LinkDefinitionsClient.cs
@@ -43,18 +43,18 @@ namespace Laserfiche.Repository.Api.Client
         public async Task GetLinkDefinitionsForEachAsync(Func<ODataValueContextOfIListOfEntryLinkTypeInfo, Task<bool>> callback, string repoId, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetLinkDefinitionsAsync(repoId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken);
+            var response = await GetLinkDefinitionsAsync(repoId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetLinkDefinitionsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetLinkDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ODataValueContextOfIListOfEntryLinkTypeInfo> GetLinkDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetLinkDefinitionsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetLinkDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Clients/RepositoriesClient.cs
+++ b/src/Clients/RepositoriesClient.cs
@@ -21,7 +21,7 @@ namespace Laserfiche.Repository.Api.Client
                     baseUrl = baseUrl.TrimEnd('/') + "/";
                 client_.BaseAddress = new Uri(baseUrl);
                 RepositoriesClient repositoriesClient = new RepositoriesClient(client_);
-                return await repositoriesClient.GetRepositoryListAsync(cancellationToken);
+                return await repositoriesClient.GetRepositoryListAsync(cancellationToken).ConfigureAwait(false);
             }
         }
     }

--- a/src/Clients/SearchesClient.cs
+++ b/src/Clients/SearchesClient.cs
@@ -80,35 +80,35 @@ namespace Laserfiche.Repository.Api.Client
 
         {
             // Initial request
-            var response = await GetSearchResultsAsync(repoId, searchToken, groupByEntryType, refresh, fields, formatFields, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);
+            var response = await GetSearchResultsAsync(repoId, searchToken, groupByEntryType, refresh, fields, formatFields, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetSearchResultsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetSearchResultsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task GetSearchContextHitsForEachAsync(Func<ODataValueContextOfIListOfContextHit, Task<bool>> callback, string repoId, string searchToken, int rowNumber, string prefer = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetSearchContextHitsAsync(repoId, searchToken, rowNumber, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken);
+            var response = await GetSearchContextHitsAsync(repoId, searchToken, rowNumber, MergeMaxSizeIntoPrefer(maxPageSize, prefer), select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetSearchContextHitsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetSearchContextHitsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ODataValueContextOfIListOfEntry> GetSearchResultsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchResultsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchResultsSendAsync, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ODataValueContextOfIListOfContextHit> GetSearchContextHitsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchContextHitsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetSearchContextHitsSendAsync, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Clients/TagDefinitionsClient.cs
+++ b/src/Clients/TagDefinitionsClient.cs
@@ -44,18 +44,18 @@ namespace Laserfiche.Repository.Api.Client
         public async Task GetTagDefinitionsForEachAsync(Func<ODataValueContextOfIListOfWTagInfo, Task<bool>> callback, string repoId, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetTagDefinitionsAsync(repoId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);
+            var response = await GetTagDefinitionsAsync(repoId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTagDefinitionsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTagDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ODataValueContextOfIListOfWTagInfo> GetTagDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagDefinitionsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTagDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Clients/TemplateDefinitionsClient.cs
+++ b/src/Clients/TemplateDefinitionsClient.cs
@@ -103,52 +103,52 @@ namespace Laserfiche.Repository.Api.Client
         public async Task GetTemplateDefinitionsForEachAsync(Func<ODataValueContextOfIListOfWTemplateInfo, Task<bool>> callback, string repoId, string templateName = null, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetTemplateDefinitionsAsync(repoId, templateName, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);
+            var response = await GetTemplateDefinitionsAsync(repoId, templateName, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTemplateDefinitionsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTemplateDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task GetTemplateFieldDefinitionsForEachAsync(Func<ODataValueContextOfIListOfTemplateFieldInfo, Task<bool>> callback, string repoId, int templateId, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetTemplateFieldDefinitionsAsync(repoId, templateId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count);
+            var response = await GetTemplateFieldDefinitionsAsync(repoId, templateId, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTemplateFieldDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task GetTemplateFieldDefinitionsByTemplateNameForEachAsync(Func<ODataValueContextOfIListOfTemplateFieldInfo, Task<bool>> callback, string repoId, string templateName, string prefer = null, string culture = null, string select = null, string orderby = null, int? top = null, int? skip = null, bool? count = null, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
             // Initial request
-            var response = await GetTemplateFieldDefinitionsByTemplateNameAsync(repoId, templateName, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken);
+            var response = await GetTemplateFieldDefinitionsByTemplateNameAsync(repoId, templateName, MergeMaxSizeIntoPrefer(maxPageSize, prefer), culture, select, orderby, top, skip, count, cancellationToken).ConfigureAwait(false);
 
             // Further requests
-            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response))
+            while (!cancellationToken.IsCancellationRequested && response != null && await callback(response).ConfigureAwait(false))
             {
-                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTemplateFieldDefinitionsByTemplateNameSendAsync, cancellationToken);
+                response = await GetNextLinkAsync(_httpClient, response.OdataNextLink, MergeMaxSizeIntoPrefer(maxPageSize, prefer), GetTemplateFieldDefinitionsByTemplateNameSendAsync, cancellationToken).ConfigureAwait(false);
             }
         }
 
         public async Task<ODataValueContextOfIListOfWTemplateInfo> GetTemplateDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateDefinitionsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ODataValueContextOfIListOfTemplateFieldInfo> GetTemplateFieldDefinitionsNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
         }
 
         public async Task<ODataValueContextOfIListOfTemplateFieldInfo> GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(string nextLink, int? maxPageSize = null, CancellationToken cancellationToken = default)
         {
-            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken);
+            return await GetNextLinkAsync(_httpClient, nextLink, MergeMaxSizeIntoPrefer(maxPageSize, null), GetTemplateFieldDefinitionsSendAsync, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/Laserfiche.Repository.Api.Client.csproj
+++ b/src/Laserfiche.Repository.Api.Client.csproj
@@ -16,6 +16,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+	<EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Laserfiche.Repository.Api.Client.csproj
+++ b/src/Laserfiche.Repository.Api.Client.csproj
@@ -16,7 +16,7 @@
     <RepositoryType>GitHub</RepositoryType>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	<EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/RepositoryApiClientHandler.cs
+++ b/src/RepositoryApiClientHandler.cs
@@ -22,8 +22,8 @@ namespace Laserfiche.Repository.Api.Client
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            return await SendExAsync(request, cancellationToken, true)
-                ?? await SendExAsync(request, cancellationToken, false);
+            return await SendExAsync(request, cancellationToken, true).ConfigureAwait(false)
+                ?? await SendExAsync(request, cancellationToken, false).ConfigureAwait(false);
         }
 
         private async Task<HttpResponseMessage> SendExAsync(HttpRequestMessage request, CancellationToken cancellationToken, bool returnNullIfRetriable)
@@ -31,7 +31,7 @@ namespace Laserfiche.Repository.Api.Client
             HttpResponseMessage response;
 
             // Sets the authorization header
-            var beforeSendResult = await _httpRequestHandler.BeforeSendAsync(request, cancellationToken);
+            var beforeSendResult = await _httpRequestHandler.BeforeSendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (_baseAddress == null || (_baseUrlDebug == null && !_baseAddress.Host.EndsWith(beforeSendResult.RegionalDomain)))
             {
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client
 
             try
             {
-                response = await base.SendAsync(request, cancellationToken);
+                response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
                 if (returnNullIfRetriable && IsTransientHttpStatusCode(response.StatusCode) && IsIdempotentHttpMethod(request.Method))
                 {
                     return null;
@@ -59,7 +59,7 @@ namespace Laserfiche.Repository.Api.Client
                 }
             }
 
-            bool shouldRetry = await _httpRequestHandler.AfterSendAsync(response, cancellationToken);
+            bool shouldRetry = await _httpRequestHandler.AfterSendAsync(response, cancellationToken).ConfigureAwait(false);
             if (returnNullIfRetriable && shouldRetry)
             {
                 return null;

--- a/tests/integration/AccessTokens/InvalidateServerSessionTest.cs
+++ b/tests/integration/AccessTokens/InvalidateServerSessionTest.cs
@@ -20,7 +20,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.AccessTokens
                 return;
             }
 
-            var result = await client.ServerSessionClient.InvalidateServerSessionAsync(RepositoryId);
+            var result = await client.ServerSessionClient.InvalidateServerSessionAsync(RepositoryId).ConfigureAwait(false);
             Assert.AreEqual(true, result.Value);
         }
     }

--- a/tests/integration/AccessTokens/RefreshServerSessionTest.cs
+++ b/tests/integration/AccessTokens/RefreshServerSessionTest.cs
@@ -22,7 +22,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.AccessTokens
             }
 
             var currentTime = DateTime.UtcNow;
-            var refreshResult = await client.ServerSessionClient.RefreshServerSessionAsync(RepositoryId);
+            var refreshResult = await client.ServerSessionClient.RefreshServerSessionAsync(RepositoryId).ConfigureAwait(false);
             var expireTime = refreshResult?.Value;
             Assert.IsNotNull(expireTime);
             Assert.IsTrue(currentTime < expireTime.Value.UtcDateTime);

--- a/tests/integration/Attributes/GetAttributeKeysTest.cs
+++ b/tests/integration/Attributes/GetAttributeKeysTest.cs
@@ -15,7 +15,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
         [TestMethod]
         public async Task GetAttributes_ReturnAttributes()
         {
-            var response = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(RepositoryId);
+            var response = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(RepositoryId).ConfigureAwait(false);
             Assert.IsNotNull(response.Value);
         }
 
@@ -38,8 +38,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
                 }
             }
 
-            await client.AttributesClient.GetTrusteeAttributeKeyValuePairsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.AttributesClient.GetTrusteeAttributeKeyValuePairsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -61,7 +61,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsNextLinkAsync(nextLink, maxPageSize);
+            result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Attributes/GetAttributeValueByKeyTest.cs
+++ b/tests/integration/Attributes/GetAttributeValueByKeyTest.cs
@@ -16,12 +16,12 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Attributes
         [TestMethod]
         public async Task GetAttributeByKey_ReturnAttribute()
         {
-            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(RepositoryId);
+            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(RepositoryId).ConfigureAwait(false);
             var attributeKeys = result.Value;
             Assert.IsNotNull(attributeKeys);
             Assert.IsTrue(attributeKeys.Count > 0, "No attribute keys exist on the user.");
 
-            var attribute = await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(RepositoryId, attributeKeys.First().Key);
+            var attribute = await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(RepositoryId, attributeKeys.First().Key).ConfigureAwait(false);
             Assert.IsTrue(!string.IsNullOrEmpty(attribute.Value));
         }
     }

--- a/tests/integration/AuditReasons/GetAuditReasonsTest.cs
+++ b/tests/integration/AuditReasons/GetAuditReasonsTest.cs
@@ -15,7 +15,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.AuditReasons
         [TestMethod]
         public async Task GetAuditReasons_ReturnAuditReasons()
         {
-            var auditReasons = await client.AuditReasonsClient.GetAuditReasonsAsync(RepositoryId);
+            var auditReasons = await client.AuditReasonsClient.GetAuditReasonsAsync(RepositoryId).ConfigureAwait(false);
 
             Assert.IsNotNull(auditReasons);
             Assert.IsNotNull(auditReasons.DeleteEntry);

--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -110,7 +110,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = entryName
             };
-            var newEntry = await client?.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: autoRename);
+            var newEntry = await (client?.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: autoRename)).ConfigureAwait(false);
             Assert.IsNotNull(newEntry);
             Assert.AreEqual(parentEntryId, newEntry.ParentId);
             Assert.AreEqual(EntryType.Folder, newEntry.EntryType);
@@ -119,9 +119,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
 
         public async Task DeleteEntry(IRepositoryApiClient client, int entryId, DeleteEntryWithAuditReason auditReason = null)
         {
-            var operation = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entryId, auditReason);
+            var operation = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entryId, auditReason).ConfigureAwait(false);
             Assert.IsNotNull(operation.Token);
-            var progress = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, operation.Token);
+            var progress = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, operation.Token).ConfigureAwait(false);
             Assert.IsTrue(progress.Status == OperationStatus.InProgress || progress.Status == OperationStatus.Completed);
         }
 
@@ -133,7 +133,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
             using (var fileStream = File.OpenRead(fileLocation))
             {
                 var electronicDocument = new FileParameter(fileStream, "test", "application/pdf");
-                var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, name, autoRename: true, electronicDocument: electronicDocument, request: request);
+                var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, name, autoRename: true, electronicDocument: electronicDocument, request: request).ConfigureAwait(false);
 
                 var operations = result.Operations;
                 Assert.IsNotNull(operations?.EntryCreate);

--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -110,7 +110,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = entryName
             };
-            var newEntry = await (client?.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: autoRename)).ConfigureAwait(false);
+            var newEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: autoRename).ConfigureAwait(false);
             Assert.IsNotNull(newEntry);
             Assert.AreEqual(parentEntryId, newEntry.ParentId);
             Assert.AreEqual(EntryType.Folder, newEntry.EntryType);

--- a/tests/integration/Entries/CopyEntryAsyncTest.cs
+++ b/tests/integration/Entries/CopyEntryAsyncTest.cs
@@ -24,7 +24,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 if (entry != null)
                 {
                     DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
                 }
             }
         }
@@ -34,7 +34,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         {
             // Create a new folder that contains the created entry
             var testFolderName = "RepositoryApiClientIntegrationTest .Net CreateCopyEntry_CopyEntry_test_folder";
-            var testFolder = await CreateEntry(client, testFolderName);
+            var testFolder = await CreateEntry(client, testFolderName).ConfigureAwait(false);
             createdEntries.Add(testFolder);
 
             // Create new entry
@@ -44,7 +44,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = newEntryName
             };
-            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, testFolder.Id, request, autoRename: true);
+            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, testFolder.Id, request, autoRename: true).ConfigureAwait(false);
             Assert.IsNotNull(targetEntry);
             Assert.AreEqual(testFolder.Id, targetEntry.ParentId);
             Assert.AreEqual(EntryType.Folder, targetEntry.EntryType);
@@ -55,12 +55,12 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = "RepositoryApiClientIntegrationTest .Net CopiedEntry",
                 SourceId = targetEntry.Id
             };
-            var copyResult = await client.EntriesClient.CopyEntryAsync(RepositoryId, testFolder.Id, copyRequest, autoRename: true);
+            var copyResult = await client.EntriesClient.CopyEntryAsync(RepositoryId, testFolder.Id, copyRequest, autoRename: true).ConfigureAwait(false);
             var opToken = copyResult.Token;
 
             // Wait for the copy operation to finish
-            await Task.Delay(5000);
-            var opResponse = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, opToken);
+            await Task.Delay(5000).ConfigureAwait(false);
+            var opResponse = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, opToken).ConfigureAwait(false);
             Assert.AreEqual(OperationStatus.Completed, opResponse.Status);
         }
     }

--- a/tests/integration/Entries/CreateCopyEntryTest.cs
+++ b/tests/integration/Entries/CreateCopyEntryTest.cs
@@ -25,7 +25,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 if (entry != null)
                 {
                     DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
                 }
             }
         }
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = newEntryName
             };
 
-            var entry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            var entry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
             Assert.IsNotNull(entry);
             createdEntries.Add(entry);
             Assert.AreEqual(parentEntryId, entry.ParentId);
@@ -60,7 +60,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = newEntryName
             };
-            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
             Assert.IsNotNull(targetEntry);
             createdEntries.Add(targetEntry);
             Assert.AreEqual(parentEntryId, targetEntry.ParentId);
@@ -74,7 +74,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = newEntryName,
                 TargetId = targetEntry.Id
             };
-            var shortcut = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            var shortcut = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
             Assert.IsNotNull(shortcut);
             createdEntries.Add(shortcut);
             Assert.AreEqual(parentEntryId, shortcut.ParentId);
@@ -96,7 +96,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = newEntryName
             };
-            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
             Assert.IsNotNull(targetEntry);
             createdEntries.Add(targetEntry);
             Assert.AreEqual(parentEntryId, targetEntry.ParentId);
@@ -110,7 +110,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = newEntryName,
                 TargetId = targetEntry.Id
             };
-            var shortcut = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            var shortcut = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
 
             Assert.IsNotNull(shortcut);
             createdEntries.Add(shortcut);
@@ -123,7 +123,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = "RepositoryApiClientIntegrationTest .Net CopiedEntry",
                 SourceId = shortcut.Id
             };
-            var newEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            var newEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
             
             createdEntries.Add(newEntry);
             Assert.IsTrue(newEntry.Name.StartsWith(request.Name));
@@ -144,7 +144,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 EntryType = PostEntryChildrenEntryType.Folder,
                 Name = newEntryName
             };
-            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            var targetEntry = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
             Assert.IsNotNull(targetEntry);
             createdEntries.Add(targetEntry);
             Assert.AreEqual(parentEntryId, targetEntry.ParentId);
@@ -156,7 +156,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = "RepositoryApiClientIntegrationTest .Net CopiedEntry",
                 SourceId = targetEntry.Id
             };
-            _ = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true);
+            _ = await client.EntriesClient.CreateOrCopyEntryAsync(RepositoryId, parentEntryId, request, autoRename: true).ConfigureAwait(false);
         }
     }
 }

--- a/tests/integration/Entries/DeleteEntryTest.cs
+++ b/tests/integration/Entries/DeleteEntryTest.cs
@@ -15,9 +15,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task DeleteEntry_ReturnOperationToken()
         {
-            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net DeleteFolder");
+            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net DeleteFolder").ConfigureAwait(false);
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-            var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body);
+            var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body).ConfigureAwait(false);
             var token = result.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
         }

--- a/tests/integration/Entries/GetDocumentContentTypeTest.cs
+++ b/tests/integration/Entries/GetDocumentContentTypeTest.cs
@@ -23,16 +23,16 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (createdEntryId != 0)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body).ConfigureAwait(false);
             }
         }
 
         [TestMethod]
         public async Task GetDocumentContentTypeAsync_ReturnHeaders()
         {
-            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContentTypeAsync");
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContentTypeAsync").ConfigureAwait(false);
 
-            var response = await client.EntriesClient.GetDocumentContentTypeAsync(RepositoryId, createdEntryId);
+            var response = await client.EntriesClient.GetDocumentContentTypeAsync(RepositoryId, createdEntryId).ConfigureAwait(false);
 
             Assert.AreEqual(200, response.StatusCode);
             Assert.IsTrue(response.Headers.ContainsKey("Content-Type"));
@@ -46,7 +46,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             string repositoryId = "fakeRepository";
             try
             {
-                await client.EntriesClient.GetDocumentContentTypeAsync(repositoryId, entryId);
+                await client.EntriesClient.GetDocumentContentTypeAsync(repositoryId, entryId).ConfigureAwait(false);
             }
             catch (ApiException e)
             {

--- a/tests/integration/Entries/GetDynamicFieldsTest.cs
+++ b/tests/integration/Entries/GetDynamicFieldsTest.cs
@@ -17,14 +17,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task GetDynamicFields_ReturnDynamicFields()
         {
             // Get a template definition id
-            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var templateDefinitions = templateDefinitionResult.Value;
             Assert.IsNotNull(templateDefinitions);
             Assert.IsTrue(templateDefinitions.Count > 0, "No template definitions exist in the repository.");
 
             int entryId = 1;
             var request = new GetDynamicFieldLogicValueRequest() { TemplateId = templateDefinitions.First().Id };
-            var result = await client.EntriesClient.GetDynamicFieldValuesAsync(RepositoryId, entryId, request);
+            var result = await client.EntriesClient.GetDynamicFieldValuesAsync(RepositoryId, entryId, request).ConfigureAwait(false);
 
             Assert.IsNotNull(result);
         }

--- a/tests/integration/Entries/GetEdocTest.cs
+++ b/tests/integration/Entries/GetEdocTest.cs
@@ -28,16 +28,16 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (createdEntryId != 0)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body).ConfigureAwait(false);
             }
         }
 
         [TestMethod]
         public async Task GetEdoc_ReturnDocument()
         {
-            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContent");
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContent").ConfigureAwait(false);
 
-            using (var response = await client.EntriesClient.ExportDocumentAsync(RepositoryId, createdEntryId))
+            using (var response = await client.EntriesClient.ExportDocumentAsync(RepositoryId, createdEntryId).ConfigureAwait(false))
             {
                 Assert.AreEqual(200, response.StatusCode);
                 Assert.IsTrue(response.Headers.ContainsKey("Content-Type"));
@@ -47,7 +47,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 fileToWriteTo = Path.GetTempFileName();
                 using (Stream streamToWriteTo = File.Open(fileToWriteTo, FileMode.Create))
                 {
-                    await response.Stream.CopyToAsync(streamToWriteTo);
+                    await response.Stream.CopyToAsync(streamToWriteTo).ConfigureAwait(false);
                 }
             }
         }

--- a/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
+++ b/tests/integration/Entries/GetEdocWithAuditReasonTest.cs
@@ -28,17 +28,17 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (createdEntryId != 0)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body).ConfigureAwait(false);
             }
         }
 
         [TestMethod]
         public async Task Export_document_with_audit_reasonAsync_ReturnDocument()
         {
-            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContent AuditReason");
+            createdEntryId = await CreateDocument("RepositoryApiClientIntegrationTest .Net GetDocumentContent AuditReason").ConfigureAwait(false);
             var request = new GetEdocWithAuditReasonRequest();
 
-            using (var response = await client.EntriesClient.ExportDocumentWithAuditReasonAsync(RepositoryId, createdEntryId, request))
+            using (var response = await client.EntriesClient.ExportDocumentWithAuditReasonAsync(RepositoryId, createdEntryId, request).ConfigureAwait(false))
             {
                 Assert.AreEqual(200, response.StatusCode);
                 Assert.IsTrue(response.Headers.ContainsKey("Content-Type"));
@@ -48,7 +48,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 fileToWriteTo = Path.GetTempFileName();
                 using (Stream streamToWriteTo = File.Open(fileToWriteTo, FileMode.Create))
                 {
-                    await response.Stream.CopyToAsync(streamToWriteTo);
+                    await response.Stream.CopyToAsync(streamToWriteTo).ConfigureAwait(false);
                 }
             }
         }

--- a/tests/integration/Entries/GetEntryFieldsTest.cs
+++ b/tests/integration/Entries/GetEntryFieldsTest.cs
@@ -16,7 +16,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task GetEntryFields_ReturnFields()
         {
             int entryId = 1;
-            var result = await client.EntriesClient.GetFieldValuesAsync(RepositoryId, entryId);
+            var result = await client.EntriesClient.GetFieldValuesAsync(RepositoryId, entryId).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
@@ -40,8 +40,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 }
             }
 
-            await client.EntriesClient.GetFieldValuesForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.EntriesClient.GetFieldValuesForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.EntriesClient.GetFieldValuesAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.EntriesClient.GetFieldValuesAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -64,7 +64,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.EntriesClient.GetFieldValuesNextLinkAsync(nextLink, maxPageSize);
+            result = await client.EntriesClient.GetFieldValuesNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Entries/GetEntryLinksTest.cs
+++ b/tests/integration/Entries/GetEntryLinksTest.cs
@@ -16,7 +16,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task GetEntryLinks_ReturnLinks()
         {
             int entryId = 1;
-            var result = await client.EntriesClient.GetLinkValuesFromEntryAsync(RepositoryId, entryId);
+            var result = await client.EntriesClient.GetLinkValuesFromEntryAsync(RepositoryId, entryId).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
@@ -40,8 +40,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 }
             }
 
-            await client.EntriesClient.GetLinkValuesFromEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.EntriesClient.GetLinkValuesFromEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             int maxPageSize = 1;
 
             // Initial request
-            var response = await client.EntriesClient.GetLinkValuesFromEntryAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            var response = await client.EntriesClient.GetLinkValuesFromEntryAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(response);
 
             if (response.Value.Count == 0)
@@ -64,7 +64,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.IsTrue(response.Value.Count <= maxPageSize);
 
             // Paging request
-            response = await client.EntriesClient.GetLinkValuesFromEntryNextLinkAsync(nextLink, maxPageSize);
+            response = await client.EntriesClient.GetLinkValuesFromEntryNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(response);
             Assert.IsTrue(response.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Entries/GetEntryListingTest.cs
+++ b/tests/integration/Entries/GetEntryListingTest.cs
@@ -16,7 +16,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task GetEntryListing_ReturnEntries()
         {
             int entryId = 1;
-            var result = await client.EntriesClient.GetEntryListingAsync(RepositoryId, entryId);
+            var result = await client.EntriesClient.GetEntryListingAsync(RepositoryId, entryId).ConfigureAwait(false);
             var entries = result.Value;
             Assert.IsNotNull(entries);
             foreach (var entry in entries)
@@ -45,8 +45,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 }
             }
 
-            await client.EntriesClient.GetEntryListingForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.EntriesClient.GetEntryListingForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             int maxPageSize = 1;
             
             // Initial request
-            var result = await client.EntriesClient.GetEntryListingAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.EntriesClient.GetEntryListingAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -69,7 +69,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.EntriesClient.GetEntryListingNextLinkAsync(nextLink, maxPageSize);
+            result = await client.EntriesClient.GetEntryListingNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Entries/GetEntryTagsTest.cs
+++ b/tests/integration/Entries/GetEntryTagsTest.cs
@@ -16,7 +16,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task GetEntryTags_ReturnTags()
         {
             int entryId = 1;
-            var result = await client.EntriesClient.GetTagsAssignedToEntryAsync(RepositoryId, entryId);
+            var result = await client.EntriesClient.GetTagsAssignedToEntryAsync(RepositoryId, entryId).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
@@ -40,8 +40,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 }
             }
 
-            await client.EntriesClient.GetTagsAssignedToEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.EntriesClient.GetTagsAssignedToEntryForEachAsync(PagingCallback, RepositoryId, entryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -51,7 +51,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.EntriesClient.GetTagsAssignedToEntryAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.EntriesClient.GetTagsAssignedToEntryAsync(RepositoryId, entryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -64,7 +64,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.EntriesClient.GetTagsAssignedToEntryNextLinkAsync(nextLink, maxPageSize);
+            result = await client.EntriesClient.GetTagsAssignedToEntryNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Entries/GetEntryTest.cs
+++ b/tests/integration/Entries/GetEntryTest.cs
@@ -24,7 +24,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (createdEntryId != 0)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body).ConfigureAwait(false);
             }
         }
 
@@ -32,7 +32,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         public async Task GetEntry_ReturnRootFolder()
         {
             int entryId = 1;
-            var entry = await client.EntriesClient.GetEntryAsync(RepositoryId, entryId);
+            var entry = await client.EntriesClient.GetEntryAsync(RepositoryId, entryId).ConfigureAwait(false);
             Assert.IsNotNull(entry);
             Assert.AreEqual(typeof(Folder), entry.GetType());
             Assert.AreEqual(entryId, entry.Id);
@@ -48,7 +48,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             using (var fileStream = File.OpenRead(fileLocation))
             {
                 var electronicDocument = new FileParameter(fileStream, "test", "application/pdf");
-                var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request);
+                var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request).ConfigureAwait(false);
 
                 var operations = result.Operations;
                 Assert.IsNotNull(operations?.EntryCreate);
@@ -63,8 +63,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task GetEntry_ReturnDocument()
         {
-            createdEntryId = await CreateDocument();
-            var entry = await client.EntriesClient.GetEntryAsync(RepositoryId, createdEntryId);
+            createdEntryId = await CreateDocument().ConfigureAwait(false);
+            var entry = await client.EntriesClient.GetEntryAsync(RepositoryId, createdEntryId).ConfigureAwait(false);
             Assert.IsNotNull(entry);
             Assert.AreEqual(typeof(Document), entry.GetType());
             Assert.AreEqual(createdEntryId, entry.Id);
@@ -78,7 +78,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             string repositoryId = "fakeRepository";
             try
             {
-                await client.EntriesClient.GetEntryAsync(repositoryId, entryId);
+                await client.EntriesClient.GetEntryAsync(repositoryId, entryId).ConfigureAwait(false);
             }
             catch (ApiException e)
             {

--- a/tests/integration/Entries/ImportDocumentTest.cs
+++ b/tests/integration/Entries/ImportDocumentTest.cs
@@ -29,7 +29,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (createdEntryId != 0)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, createdEntryId, body).ConfigureAwait(false);
             }
         }
 
@@ -48,7 +48,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             var electronicDocument = GetFileParameter();
             var request = new PostEntryWithEdocMetadataRequest();
 
-            var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request);
+            var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request).ConfigureAwait(false);
 
             var operations = result.Operations;
             createdEntryId = operations.EntryCreate.EntryId;
@@ -64,13 +64,13 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         {
             // Find a template definition with no required fields
             WTemplateInfo template = null;
-            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var templateDefinitions = templateDefinitionResult.Value;
             Assert.IsNotNull(templateDefinitions);
             Assert.IsTrue(templateDefinitions.Count > 0, "No template definitions exist in the repository.");
             foreach (var templateDefinition in templateDefinitions)
             {
-                var templateDefinitionFieldsResult = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, templateDefinition.Id);
+                var templateDefinitionFieldsResult = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, templateDefinition.Id).ConfigureAwait(false);
                 if (templateDefinitionFieldsResult.Value != null && templateDefinitionFieldsResult.Value.All(f => !f.IsRequired))
                 {
                     template = templateDefinition;
@@ -87,7 +87,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Template = template.Name
             };
 
-            var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request);
+            var result = await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request).ConfigureAwait(false);
 
             var operations = result.Operations;
             createdEntryId = operations.EntryCreate.EntryId;
@@ -113,7 +113,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
 
             try
             {
-                await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request);
+                await client.EntriesClient.ImportDocumentAsync(RepositoryId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request).ConfigureAwait(false);
             }
             catch (ApiException e)
             {

--- a/tests/integration/Entries/MoveEntryTest.cs
+++ b/tests/integration/Entries/MoveEntryTest.cs
@@ -24,7 +24,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 if (entry != null)
                 {
                     DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
                 }
             }
         }
@@ -32,9 +32,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task MoveAndRenameEntry_ReturnEntry()
         {
-            var parentFolder = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ParentFolder");
+            var parentFolder = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ParentFolder").ConfigureAwait(false);
             createdEntries.Add(parentFolder);
-            var childFolder = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ChildFolder");
+            var childFolder = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ChildFolder").ConfigureAwait(false);
             createdEntries.Add(childFolder);
             var request = new PatchEntryRequest()
             {
@@ -42,7 +42,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 Name = "RepositoryApiClientIntegrationTest .Net MovedFolder"
             };
 
-            var movedEntry = await client.EntriesClient.MoveOrRenameEntryAsync(RepositoryId, childFolder.Id, request, autoRename: true);
+            var movedEntry = await client.EntriesClient.MoveOrRenameEntryAsync(RepositoryId, childFolder.Id, request, autoRename: true).ConfigureAwait(false);
 
             Assert.IsNotNull(movedEntry);
             Assert.AreEqual(childFolder.Id, movedEntry.Id);

--- a/tests/integration/Entries/RemoveTemplateFromEntryTest.cs
+++ b/tests/integration/Entries/RemoveTemplateFromEntryTest.cs
@@ -22,7 +22,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (entry != null)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
             }
         }
 
@@ -31,13 +31,13 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         {
             // Find a template definition with no required fields
             WTemplateInfo template = null;
-            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var templateDefinitions = templateDefinitionResult.Value;
             Assert.IsNotNull(templateDefinitions);
             Assert.IsTrue(templateDefinitions.Count > 0, "No template definitions exist in the repository.");
             foreach (var templateDefinition in templateDefinitions)
             {
-                var templateDefinitionFieldsResult = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, templateDefinition.Id);
+                var templateDefinitionFieldsResult = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, templateDefinition.Id).ConfigureAwait(false);
                 if (templateDefinitionFieldsResult.Value != null && templateDefinitionFieldsResult.Value.All(f => !f.IsRequired))
                 {
                     template = templateDefinition;
@@ -51,13 +51,13 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 TemplateName = template.Name
             };
-            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net RemoveTemplateFromEntry");
-            var setTemplateEntryResult = await client.EntriesClient.WriteTemplateValueToEntryAsync(RepositoryId, entry.Id, request);
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net RemoveTemplateFromEntry").ConfigureAwait(false);
+            var setTemplateEntryResult = await client.EntriesClient.WriteTemplateValueToEntryAsync(RepositoryId, entry.Id, request).ConfigureAwait(false);
             Assert.IsNotNull(setTemplateEntryResult);
             Assert.AreEqual(template.Name, setTemplateEntryResult.TemplateName);
 
             // Delete the template on the entry
-            var deleteTemplateResponse = await client.EntriesClient.DeleteAssignedTemplateAsync(RepositoryId, entry.Id);
+            var deleteTemplateResponse = await client.EntriesClient.DeleteAssignedTemplateAsync(RepositoryId, entry.Id).ConfigureAwait(false);
             var returnedEntry = deleteTemplateResponse;
             Assert.IsNotNull(returnedEntry);
             Assert.AreEqual(entry.Id, returnedEntry.Id);

--- a/tests/integration/Entries/SetFieldsTest.cs
+++ b/tests/integration/Entries/SetFieldsTest.cs
@@ -23,7 +23,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (entry != null)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
             }
         }
 
@@ -33,7 +33,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             // Find a string field
             WFieldInfo field = null;
             string fieldValue = "a";
-            var fieldDefinitionsResult = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId);
+            var fieldDefinitionsResult = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var fieldDefinitions = fieldDefinitionsResult.Value;
             Assert.IsNotNull(fieldDefinitions);
             foreach(var fieldDefinition in fieldDefinitions)
@@ -56,9 +56,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                     }
                 }
             };
-            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetFields");
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetFields").ConfigureAwait(false);
 
-            var result = await client.EntriesClient.AssignFieldValuesAsync(RepositoryId, entry.Id, requestBody);
+            var result = await client.EntriesClient.AssignFieldValuesAsync(RepositoryId, entry.Id, requestBody).ConfigureAwait(false);
             var fields = result.Value;
             Assert.IsNotNull(fields);
             Assert.AreEqual(1, fields.Count);

--- a/tests/integration/Entries/SetLinksTest.cs
+++ b/tests/integration/Entries/SetLinksTest.cs
@@ -25,7 +25,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 if (entry != null)
                 {
                     DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                    await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
                 }
             }
         }
@@ -33,9 +33,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task SetLinks_ReturnLinks()
         {
-            var sourceEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetLinks Source");
+            var sourceEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetLinks Source").ConfigureAwait(false);
             createdEntries.Add(sourceEntry);
-            var targetEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetLinks Target");
+            var targetEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetLinks Target").ConfigureAwait(false);
             createdEntries.Add(targetEntry);
             var request = new List<PutLinksRequest>()
             {
@@ -46,7 +46,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
                 }
             };
 
-            var result = await client.EntriesClient.AssignEntryLinksAsync(RepositoryId, sourceEntry.Id, request);
+            var result = await client.EntriesClient.AssignEntryLinksAsync(RepositoryId, sourceEntry.Id, request).ConfigureAwait(false);
 
             var links = result.Value;
             Assert.IsNotNull(links);

--- a/tests/integration/Entries/SetTagsTest.cs
+++ b/tests/integration/Entries/SetTagsTest.cs
@@ -23,14 +23,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (entry != null)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
             }
         }
 
         [TestMethod]
         public async Task SetTags_ReturnTags()
         {
-            var tagDefinitionsResult = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId);
+            var tagDefinitionsResult = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var tagDefinitions = tagDefinitionsResult.Value;
             Assert.IsNotNull(tagDefinitions);
             Assert.IsTrue(tagDefinitions.Count > 0, "No tag definitions exist in the repository.");
@@ -39,9 +39,9 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 Tags = new List<string>() { tag }
             };
-            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetTags");
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net SetTags").ConfigureAwait(false);
 
-            var result = await client.EntriesClient.AssignTagsAsync(RepositoryId, entry.Id, request);
+            var result = await client.EntriesClient.AssignTagsAsync(RepositoryId, entry.Id, request).ConfigureAwait(false);
             var tags = result.Value;
             Assert.IsNotNull(tags);
             Assert.AreEqual(request.Tags.Count, tags.Count);

--- a/tests/integration/Entries/SetTemplateTest.cs
+++ b/tests/integration/Entries/SetTemplateTest.cs
@@ -22,7 +22,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             if (entry != null)
             {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body);
+                await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, entry.Id, body).ConfigureAwait(false);
             }
         }
 
@@ -31,13 +31,13 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         {
             // Find a template definition with no required fields
             WTemplateInfo template = null;
-            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var templateDefinitionResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var templateDefinitions = templateDefinitionResult.Value;
             Assert.IsNotNull(templateDefinitions);
             Assert.IsTrue(templateDefinitions.Count > 0, "No template definitions exist in the repository.");
             foreach (var templateDefinition in templateDefinitions)
             {
-                var templateDefinitionFields = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, templateDefinition.Id);
+                var templateDefinitionFields = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, templateDefinition.Id).ConfigureAwait(false);
                 if (templateDefinitionFields.Value != null && templateDefinitionFields.Value.All(f => !f.IsRequired))
                 {
                     template = templateDefinition;
@@ -51,8 +51,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 TemplateName = template.Name
             };
-            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net DeleteTemplate");
-            var setTemplateResult = await client.EntriesClient.WriteTemplateValueToEntryAsync(RepositoryId, entry.Id, request);
+            entry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net DeleteTemplate").ConfigureAwait(false);
+            var setTemplateResult = await client.EntriesClient.WriteTemplateValueToEntryAsync(RepositoryId, entry.Id, request).ConfigureAwait(false);
             Assert.IsNotNull(setTemplateResult);
             Assert.AreEqual(template.Name, setTemplateResult.TemplateName);
         }

--- a/tests/integration/FieldDefinitions/GetFieldDefinitionByIdTest.cs
+++ b/tests/integration/FieldDefinitions/GetFieldDefinitionByIdTest.cs
@@ -16,11 +16,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
         [TestMethod]
         public async Task GetFieldDefinitionById_ReturnField()
         {
-            var allFieldDefinitionsResult = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId);
+            var allFieldDefinitionsResult = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstFieldDefinition = allFieldDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstFieldDefinition, "No field definitions exist in the repository.");
 
-            var fieldDefinition = await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(RepositoryId, firstFieldDefinition.Id);
+            var fieldDefinition = await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(RepositoryId, firstFieldDefinition.Id).ConfigureAwait(false);
 
             Assert.IsNotNull(fieldDefinition);
             Assert.AreEqual(firstFieldDefinition.Id, fieldDefinition.Id);

--- a/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
+++ b/tests/integration/FieldDefinitions/GetFieldDefinitionsTest.cs
@@ -15,7 +15,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
         [TestMethod]
         public async Task GetFieldDefinitions_ReturnAllFields()
         {
-            var result = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId);
+            var result = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
@@ -38,8 +38,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
                 }
             }
 
-            await client.FieldDefinitionsClient.GetFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.FieldDefinitionsClient.GetFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -61,7 +61,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.FieldDefinitionsClient.GetFieldDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            result = await client.FieldDefinitionsClient.GetFieldDefinitionsNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj
+++ b/tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj
@@ -6,6 +6,7 @@
     <Authors>Laserfiche</Authors>
     <Copyright>Apache License 2.0</Copyright>
     <PackageProjectUrl>https://www.laserfiche.com/</PackageProjectUrl>
+	<EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj
+++ b/tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Authors>Laserfiche</Authors>
     <Copyright>Apache License 2.0</Copyright>
     <PackageProjectUrl>https://www.laserfiche.com/</PackageProjectUrl>
-	<EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/integration/LinkDefinitions/GetLinkDefinitionByIdTest.cs
+++ b/tests/integration/LinkDefinitions/GetLinkDefinitionByIdTest.cs
@@ -16,11 +16,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.LinkDefinitions
         [TestMethod]
         public async Task GetLinkDefinitionByIdAsync_ReturnLinkDefinition()
         {
-            var allLinkDefinitionsResult = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId);
+            var allLinkDefinitionsResult = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstLinkDefinition = allLinkDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstLinkDefinition, "No link definitions exist in the repository.");
 
-            var linkDefinition = await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(RepositoryId, firstLinkDefinition.LinkTypeId);
+            var linkDefinition = await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(RepositoryId, firstLinkDefinition.LinkTypeId).ConfigureAwait(false);
 
             Assert.IsNotNull(linkDefinition);
             Assert.AreEqual(firstLinkDefinition.LinkTypeId, linkDefinition.LinkTypeId);

--- a/tests/integration/LinkDefinitions/GetLinkDefinitionsTest.cs
+++ b/tests/integration/LinkDefinitions/GetLinkDefinitionsTest.cs
@@ -15,7 +15,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.LinkDefinitions
         [TestMethod]
         public async Task GetLinkDefinitionsAsync_ReturnAllLinks()
         {
-            var result = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId);
+            var result = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
@@ -38,8 +38,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.LinkDefinitions
                 }
             }
 
-            await client.LinkDefinitionsClient.GetLinkDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.LinkDefinitionsClient.GetLinkDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -48,7 +48,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.LinkDefinitions
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -61,7 +61,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.LinkDefinitions
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.LinkDefinitionsClient.GetLinkDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            result = await client.LinkDefinitionsClient.GetLinkDefinitionsNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Repositories/GetRepositoryListTest.cs
+++ b/tests/integration/Repositories/GetRepositoryListTest.cs
@@ -15,7 +15,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Repositories
         [TestMethod]
         public async Task GetRepositoryList_ReturnSuccessful()
         {
-            var result = await client.RepositoriesClient.GetRepositoryListAsync();
+            var result = await client.RepositoriesClient.GetRepositoryListAsync().ConfigureAwait(false);
             Assert.IsTrue(result.Count > 0, "No repositories found.");
 
             bool foundRepo = false;
@@ -41,7 +41,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Repositories
             {
                 return; // There's no point testing if it is a cloud environment
             }
-            var result = await RepositoriesClient.GetSelfHostedRepositoryListAsync(BaseUrl);
+            var result = await RepositoriesClient.GetSelfHostedRepositoryListAsync(BaseUrl).ConfigureAwait(false);
             Assert.IsTrue(result.Count > 0, "No repositories found.");
             Assert.IsNotNull(result);
             bool foundRepo = false;

--- a/tests/integration/RepositoryApiClientTest.cs
+++ b/tests/integration/RepositoryApiClientTest.cs
@@ -31,7 +31,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
                     return;
             }
 
-            var exception = await Assert.ThrowsExceptionAsync<ApiException>(async () => await invalidClient.EntriesClient.GetEntryAsync(RepositoryId, entryId));
+            var exception = await Assert.ThrowsExceptionAsync<ApiException>(async () => await invalidClient.EntriesClient.GetEntryAsync(RepositoryId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             Assert.AreEqual(401, exception.ProblemDetails.Status);
             Assert.AreEqual(exception.ProblemDetails.Status, exception.StatusCode);

--- a/tests/integration/Searches/CloseSearchOperationTest.cs
+++ b/tests/integration/Searches/CloseSearchOperationTest.cs
@@ -20,7 +20,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
         {
             if (!string.IsNullOrEmpty(token))
             {
-                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token);
+                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token).ConfigureAwait(false);
             }
         }
 
@@ -32,7 +32,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"search text\", option=\"DFANLT\"})"
             };
-            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
         }

--- a/tests/integration/Searches/CreateSearchOperationTest.cs
+++ b/tests/integration/Searches/CreateSearchOperationTest.cs
@@ -20,7 +20,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
         {
             if (!string.IsNullOrEmpty(token))
             {
-                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token);
+                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token).ConfigureAwait(false);
             }
         }
 
@@ -31,7 +31,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"search text\", option=\"DFANLT\"})"
             };
-            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
         }

--- a/tests/integration/Searches/GetSearchContextHitsTest.cs
+++ b/tests/integration/Searches/GetSearchContextHitsTest.cs
@@ -21,7 +21,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
         {
             if (!string.IsNullOrEmpty(token))
             {
-                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token);
+                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token).ConfigureAwait(false);
             }
         }
 
@@ -33,21 +33,21 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"*\", option=\"DFANLT\"})"
             };
-            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            await Task.Delay(5000);
+            await Task.Delay(5000).ConfigureAwait(false);
 
             // Get search results
-            var searchResultsResponse = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token);
+            var searchResultsResponse = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token).ConfigureAwait(false);
             var searchResults = searchResultsResponse.Value;
             Assert.IsNotNull(searchResults);
             Assert.IsTrue(searchResults.Count > 0, "No search results found. Cannot get context hits.");
             int rowNumber = searchResults.First().RowNumber;
 
             // Get context hits
-            var contextHitsResponse = await client.SearchesClient.GetSearchContextHitsAsync(RepositoryId, token, rowNumber);
+            var contextHitsResponse = await client.SearchesClient.GetSearchContextHitsAsync(RepositoryId, token, rowNumber).ConfigureAwait(false);
             var contextHits = contextHitsResponse.Value;
             Assert.IsNotNull(contextHits);
         }
@@ -62,14 +62,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"*\", option=\"DFANLT\"})"
             };
-            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            await Task.Delay(5000);
+            await Task.Delay(5000).ConfigureAwait(false);
 
             // Get search results
-            var searchResultsResponse = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token);
+            var searchResultsResponse = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token).ConfigureAwait(false);
             var searchResults = searchResultsResponse.Value;
             Assert.IsNotNull(searchResults);
             Assert.IsTrue(searchResults.Count > 0, "No search results found. Cannot get context hits.");
@@ -89,8 +89,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
                 }
             }
 
-            await client.SearchesClient.GetSearchContextHitsForEachAsync(PagingCallback, RepositoryId, token, rowNumber, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.SearchesClient.GetSearchContextHitsForEachAsync(PagingCallback, RepositoryId, token, rowNumber, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
     }
 }

--- a/tests/integration/Searches/GetSearchResultsTest.cs
+++ b/tests/integration/Searches/GetSearchResultsTest.cs
@@ -20,7 +20,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
         {
             if (!string.IsNullOrEmpty(token))
             {
-                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token);
+                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token).ConfigureAwait(false);
             }
         }
 
@@ -32,14 +32,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"search text\", option=\"DFANLT\"})"
             };
-            var searchResult = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var searchResult = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = searchResult.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            await Task.Delay(10000);
+            await Task.Delay(10000).ConfigureAwait(false);
 
             // Get search results
-            var searchResultsResult = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token);
+            var searchResultsResult = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token).ConfigureAwait(false);
             var searchResults = searchResultsResult.Value;
             Assert.IsNotNull(searchResults);
         }
@@ -54,11 +54,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"search text\", option=\"NLT\"})"
             };
-            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            await Task.Delay(10000);
+            await Task.Delay(10000).ConfigureAwait(false);
 
             Task<bool> PagingCallback(ODataValueContextOfIListOfEntry data)
             {
@@ -74,8 +74,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
                 }
             }
 
-            await client.SearchesClient.GetSearchResultsForEachAsync(PagingCallback, RepositoryId, token, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.SearchesClient.GetSearchResultsForEachAsync(PagingCallback, RepositoryId, token, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -88,14 +88,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"search text\", option=\"NLT\"})"
             };
-            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            await Task.Delay(10000);
+            await Task.Delay(10000).ConfigureAwait(false);
 
             // Initial request
-            var result = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.SearchesClient.GetSearchResultsAsync(RepositoryId, token, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count <= maxPageSize)
@@ -108,7 +108,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.SearchesClient.GetSearchResultsNextLinkAsync(nextLink, maxPageSize);
+            result = await client.SearchesClient.GetSearchResultsNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Searches/GetSearchStatusTest.cs
+++ b/tests/integration/Searches/GetSearchStatusTest.cs
@@ -20,7 +20,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
         {
             if (!string.IsNullOrEmpty(token))
             {
-                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token);
+                await client.SearchesClient.CancelOrCloseSearchAsync(RepositoryId, token).ConfigureAwait(false);
             }
         }
 
@@ -32,14 +32,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Searches
             {
                 SearchCommand = "({LF:Basic ~= \"search text\", option=\"DFANLT\"})"
             };
-            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request);
+            var operation = await client.SearchesClient.CreateSearchOperationAsync(RepositoryId, request).ConfigureAwait(false);
             token = operation.Token;
             Assert.IsTrue(!string.IsNullOrEmpty(token));
 
-            await Task.Delay(5000);
+            await Task.Delay(5000).ConfigureAwait(false);
 
             // Get search status
-            var searchStatus = await client.SearchesClient.GetSearchStatusAsync(RepositoryId, token);
+            var searchStatus = await client.SearchesClient.GetSearchStatusAsync(RepositoryId, token).ConfigureAwait(false);
             Assert.IsNotNull(searchStatus);
             Assert.AreEqual(token, searchStatus.OperationToken);
         }

--- a/tests/integration/SimpleSearches/SimpleSearchTest.cs
+++ b/tests/integration/SimpleSearches/SimpleSearchTest.cs
@@ -13,21 +13,21 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.SimpleSearches
         public async Task Initialize()
         {
             client = CreateClient();
-            _createdEntry = await CreateEntry(client, _entryToCreate);
+            _createdEntry = await CreateEntry(client, _entryToCreate).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task SimpleSearch_ReturnSearchResults()
         {
             var request = new SimpleSearchRequest() { SearchCommand = "({LF:Basic ~= \"search text\", option=\"DFANLT\"})" };
-            var result = await client.SimpleSearchesClient.CreateSimpleSearchOperationAsync(RepositoryId, request: request);
+            var result = await client.SimpleSearchesClient.CreateSimpleSearchOperationAsync(RepositoryId, request: request).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
         [TestCleanup]
         public async Task Cleanup()
         {
-            await DeleteEntry(client, _createdEntry.Id);
+            await DeleteEntry(client, _createdEntry.Id).ConfigureAwait(false);
         }
     }
 }

--- a/tests/integration/TagDefinitions/GetTagDefinitionsByIdTest.cs
+++ b/tests/integration/TagDefinitions/GetTagDefinitionsByIdTest.cs
@@ -16,11 +16,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
         [TestMethod]
         public async Task GetTagDefinitionsById_ReturnTag()
         {
-            var allTagDefinitionsResult = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId);
+            var allTagDefinitionsResult = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTagDefinition = allTagDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTagDefinition, "No tag definitions exist in the repository.");
 
-            var tagDefinition = await client.TagDefinitionsClient.GetTagDefinitionByIdAsync(RepositoryId, firstTagDefinition.Id);
+            var tagDefinition = await client.TagDefinitionsClient.GetTagDefinitionByIdAsync(RepositoryId, firstTagDefinition.Id).ConfigureAwait(false);
 
             Assert.IsNotNull(tagDefinition);
             Assert.AreEqual(firstTagDefinition.Id, tagDefinition.Id);

--- a/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
+++ b/tests/integration/TagDefinitions/GetTagDefinitionsTest.cs
@@ -15,7 +15,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
         [TestMethod]
         public async Task GetTagDefinitions_ReturnAllTags()
         {
-            var result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId);
+            var result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
@@ -38,21 +38,21 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
                 }
             }
 
-            await client.TagDefinitionsClient.GetTagDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.TagDefinitionsClient.GetTagDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task GetTagDefinitions_SimplePaging()
         {
             // Get total count of tags
-            var  result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId);
+            var  result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             int tagsCount = result.Value.Count;
 
             int maxPageSize = 1;
 
             // Initial request
-            result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
@@ -65,7 +65,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TagDefinitions
             Assert.IsNotNull(nextLink);
 
             // Paging request
-            result = await client.TagDefinitionsClient.GetTagDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            result = await client.TagDefinitionsClient.GetTagDefinitionsNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/Tasks/CancelOperationTest.cs
+++ b/tests/integration/Tasks/CancelOperationTest.cs
@@ -16,16 +16,16 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
         [TestMethod]
         public async Task CancelOpeartion_OperationEndedBeforeCancel()
         {
-            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net CancelOperation");
+            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net CancelOperation").ConfigureAwait(false);
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-            var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body);
+            var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body).ConfigureAwait(false);
             var token = result.Token;
             Assert.IsFalse(string.IsNullOrEmpty(token));
 
             try
             {
-                await Task.Delay(5000);
-                await client.TasksClient.CancelOperationAsync(RepositoryId, token);
+                await Task.Delay(5000).ConfigureAwait(false);
+                await client.TasksClient.CancelOperationAsync(RepositoryId, token).ConfigureAwait(false);
                 Assert.Fail("Long operation should have ended before cancel.");
             }
             catch (ApiException e)

--- a/tests/integration/Tasks/GetOperationStatusTest.cs
+++ b/tests/integration/Tasks/GetOperationStatusTest.cs
@@ -15,16 +15,16 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
         [TestMethod]
         public async Task GetOperationStatus_ReturnStatus()
         {
-            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net GetOperationStatus");
+            var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net GetOperationStatus").ConfigureAwait(false);
 
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-            var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body);
+            var result = await client.EntriesClient.DeleteEntryInfoAsync(RepositoryId, deleteEntry.Id, body).ConfigureAwait(false);
             var token = result.Token;
             Assert.IsFalse(string.IsNullOrEmpty(token));
 
-            await Task.Delay(5000);
+            await Task.Delay(5000).ConfigureAwait(false);
 
-            var operationProgress = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, token);
+            var operationProgress = await client.TasksClient.GetOperationStatusAndProgressAsync(RepositoryId, token).ConfigureAwait(false);
             Assert.IsNotNull(operationProgress);
             Assert.AreEqual(OperationStatus.Completed, operationProgress.Status);
             Assert.AreEqual(100, operationProgress.PercentComplete);

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionByIdTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionByIdTest.cs
@@ -16,11 +16,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         [TestMethod]
         public async Task GetTemplateDefinitionById_ReturnTemplate()
         {
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition, "No template definitions exist in the repository.");
 
-            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionByIdAsync(RepositoryId, firstTemplateDefinition.Id);
+            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionByIdAsync(RepositoryId, firstTemplateDefinition.Id).ConfigureAwait(false);
 
             Assert.IsNotNull(result);
             Assert.AreEqual(firstTemplateDefinition.Id, result.Id);

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
@@ -16,11 +16,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         [TestMethod]
         public async Task GetTemplateDefinitionFieldsByTemplateName_ReturnTemplateFields()
         {
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition);
 
-            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(RepositoryId, firstTemplateDefinition.Name);
+            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(RepositoryId, firstTemplateDefinition.Name).ConfigureAwait(false);
             var templateFieldDefinitions = result.Value;
 
             Assert.IsNotNull(templateFieldDefinitions);
@@ -32,7 +32,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         {
             int maxPageSize = 10;
 
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition);
 
@@ -50,21 +50,21 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                 }
             }
 
-            await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Name, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Name, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task GetTemplateDefinitionFieldsByTemplateName_SimplePaging()
         {
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition);
 
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(RepositoryId, firstTemplateDefinition.Name, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(RepositoryId, firstTemplateDefinition.Name, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             var nextLink = result.OdataNextLink;
@@ -72,7 +72,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(nextLink, maxPageSize);
+            result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
@@ -16,11 +16,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         [TestMethod]
         public async Task GetTemplateDefinitionFields_ReturnTemplateFields()
         {
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition);
 
-            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, firstTemplateDefinition.Id);
+            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, firstTemplateDefinition.Id).ConfigureAwait(false);
             var templateFieldDefinitions = result.Value;
 
             Assert.IsNotNull(templateFieldDefinitions);
@@ -32,7 +32,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         {
             int maxPageSize = 10;
 
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition);
 
@@ -50,21 +50,21 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                 }
             }
 
-            await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Id, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsForEachAsync(PagingCallback, RepositoryId, firstTemplateDefinition.Id, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
         public async Task GetTemplateDefinitionFields_SimplePaging()
         {
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition);
 
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, firstTemplateDefinition.Id, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(RepositoryId, firstTemplateDefinition.Id, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -77,7 +77,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
+++ b/tests/integration/TemplateDefinitions/GetTemplateDefinitionTest.cs
@@ -16,18 +16,18 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         [TestMethod]
         public async Task GetTemplateDefinition_ReturnAllTemplates()
         {
-            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
         }
 
         [TestMethod]
         public async Task GetTemplateDefinition_TemplateNameQueryParameter_ReturnSingleTemplate()
         {
-            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId);
+            var allTemplateDefinitionsResult = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId).ConfigureAwait(false);
             var firstTemplateDefinition = allTemplateDefinitionsResult.Value?.FirstOrDefault();
             Assert.IsNotNull(firstTemplateDefinition);
 
-            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId, templateName: firstTemplateDefinition.Name);
+            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId, templateName: firstTemplateDefinition.Name).ConfigureAwait(false);
             Assert.IsNotNull(result.Value);
             Assert.AreEqual(1, result.Value.Count);
             Assert.AreEqual(firstTemplateDefinition.Id, result.Value.FirstOrDefault().Id);
@@ -52,8 +52,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                 }
             }
 
-            await client.TemplateDefinitionsClient.GetTemplateDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize);
-            await Task.Delay(5000);
+            await client.TemplateDefinitionsClient.GetTemplateDefinitionsForEachAsync(PagingCallback, RepositoryId, maxPageSize: maxPageSize).ConfigureAwait(false);
+            await Task.Delay(5000).ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -62,7 +62,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             int maxPageSize = 1;
 
             // Initial request
-            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}");
+            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(RepositoryId, prefer: $"maxpagesize={maxPageSize}").ConfigureAwait(false);
             Assert.IsNotNull(result);
 
             if (result.Value.Count == 0)
@@ -75,7 +75,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             Assert.IsTrue(result.Value.Count <= maxPageSize);
 
             // Paging request
-            result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsNextLinkAsync(nextLink, maxPageSize);
+            result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
             Assert.IsNotNull(result);
             Assert.IsTrue(result.Value.Count <= maxPageSize);
         }

--- a/tests/unit/AccessTokens/ServerSessionsTest.cs
+++ b/tests/unit/AccessTokens/ServerSessionsTest.cs
@@ -51,7 +51,7 @@ namespace Laserfiche.Repository.Api.Client.Test.AccessTokens
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await client.ServerSessionClient.InvalidateServerSessionAsync(repoId);
+            var response = await client.ServerSessionClient.InvalidateServerSessionAsync(repoId).ConfigureAwait(false);
             Assert.True(response.Value);
 
             // also check the 'http' call was like we expected it
@@ -101,7 +101,7 @@ namespace Laserfiche.Repository.Api.Client.Test.AccessTokens
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.ServerSessionClient.InvalidateServerSessionAsync(repoId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.ServerSessionClient.InvalidateServerSessionAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // also check the 'http' call was like we expected it
             var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/ServerSession/Invalidate");
@@ -155,7 +155,7 @@ namespace Laserfiche.Repository.Api.Client.Test.AccessTokens
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await client.ServerSessionClient.RefreshServerSessionAsync(repoId);
+            var response = await client.ServerSessionClient.RefreshServerSessionAsync(repoId).ConfigureAwait(false);
             Assert.Equal(ret.Value, response.Value);
 
             // also check the 'http' call was like we expected it
@@ -205,7 +205,7 @@ namespace Laserfiche.Repository.Api.Client.Test.AccessTokens
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.ServerSessionClient.RefreshServerSessionAsync(repoId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.ServerSessionClient.RefreshServerSessionAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // also check the 'http' call was like we expected it
             var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/ServerSession/Refresh");

--- a/tests/unit/Attributes/GetAttributeKeysTest.cs
+++ b/tests/unit/Attributes/GetAttributeKeysTest.cs
@@ -55,7 +55,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Attributes
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(repoId);
+            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(repoId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -115,7 +115,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Attributes
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(repoId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -176,7 +176,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Attributes
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(repoId, everyone: true);
+            var result = await client.AttributesClient.GetTrusteeAttributeKeyValuePairsAsync(repoId, everyone: true).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Attributes/GetAttributeValueByKeyTest.cs
+++ b/tests/unit/Attributes/GetAttributeValueByKeyTest.cs
@@ -49,7 +49,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Attributes
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(repoId, attributeKey);
+            var result = await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(repoId, attributeKey).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -104,7 +104,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Attributes
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(repoId, attributeKey));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(repoId, attributeKey).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -158,7 +158,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Attributes
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(repoId, attributeKey, everyone: true);
+            var result = await client.AttributesClient.GetTrusteeAttributeValueByKeyAsync(repoId, attributeKey, everyone: true).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/AuditReasons/GetAuditReasonsTest.cs
+++ b/tests/unit/AuditReasons/GetAuditReasonsTest.cs
@@ -71,7 +71,7 @@ namespace Laserfiche.Repository.Api.Client.Test.AuditReasons
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.AuditReasonsClient.GetAuditReasonsAsync(repoId);
+            var result = await client.AuditReasonsClient.GetAuditReasonsAsync(repoId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -140,7 +140,7 @@ namespace Laserfiche.Repository.Api.Client.Test.AuditReasons
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.AuditReasonsClient.GetAuditReasonsAsync(repoId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.AuditReasonsClient.GetAuditReasonsAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/Custom/LaserficheRepositoryApiClientCustomTest.cs
+++ b/tests/unit/Custom/LaserficheRepositoryApiClientCustomTest.cs
@@ -85,7 +85,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Custom
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetEntryAsync(uriString);
+            var result = await client.EntriesClient.GetEntryAsync(uriString).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -168,7 +168,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Custom
             client.DefaultRequestHeaders.AcceptLanguage.Add(new StringWithQualityHeaderValue(acceptLanguageHeaderValue));
 
             // ACT
-            var result = await client.EntriesClient.GetEntryAsync(repoId, entry.Id);
+            var result = await client.EntriesClient.GetEntryAsync(repoId, entry.Id).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/CopyEntryAsyncTest.cs
+++ b/tests/unit/Entries/CopyEntryAsyncTest.cs
@@ -59,7 +59,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.CopyEntryAsync(repoId, entryId, request);
+            var result = await client.EntriesClient.CopyEntryAsync(repoId, entryId, request).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -127,7 +127,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.CopyEntryAsync(repoId, entryId, request));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.CopyEntryAsync(repoId, entryId, request).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -195,7 +195,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.CopyEntryAsync(repoId, entryId, request, autoRename);
+            var result = await client.EntriesClient.CopyEntryAsync(repoId, entryId, request, autoRename).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/CreateCopyEntryTest.cs
+++ b/tests/unit/Entries/CreateCopyEntryTest.cs
@@ -70,7 +70,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.CreateOrCopyEntryAsync(repoId, (int)entry.ParentId, request);
+            var result = await client.EntriesClient.CreateOrCopyEntryAsync(repoId, (int)entry.ParentId, request).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -146,7 +146,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.CreateOrCopyEntryAsync(repoId, entryId, request));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.CreateOrCopyEntryAsync(repoId, entryId, request).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -223,7 +223,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.CreateOrCopyEntryAsync(repoId, (int)entry.ParentId, request, autoRename: true);
+            var result = await client.EntriesClient.CreateOrCopyEntryAsync(repoId, (int)entry.ParentId, request, autoRename: true).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/DeleteAssignedTemplateAsyncTest.cs
+++ b/tests/unit/Entries/DeleteAssignedTemplateAsyncTest.cs
@@ -63,7 +63,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.DeleteAssignedTemplateAsync(repoId, entryId);
+            var result = await client.EntriesClient.DeleteAssignedTemplateAsync(repoId, entryId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -117,7 +117,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () =>  await client.EntriesClient.DeleteAssignedTemplateAsync(repoId, entryId));
+            await Assert.ThrowsAsync<ApiException>(async () =>  await client.EntriesClient.DeleteAssignedTemplateAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Entries/DeleteEntryTest.cs
+++ b/tests/unit/Entries/DeleteEntryTest.cs
@@ -59,7 +59,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.DeleteEntryInfoAsync(repoId, entryId, request);
+            var result = await client.EntriesClient.DeleteEntryInfoAsync(repoId, entryId, request).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -122,7 +122,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.DeleteEntryInfoAsync(repoId, entryId, request));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.DeleteEntryInfoAsync(repoId, entryId, request).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/Entries/ExportDocumentAsyncTest.cs
+++ b/tests/unit/Entries/ExportDocumentAsyncTest.cs
@@ -77,7 +77,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                     var client = new RepositoryApiClient(httpClient);
 
                     // ACT
-                    var swaggerResponse = await client.EntriesClient.ExportDocumentAsync(repoId, entryId, range : "bytes=0-200, 300-400");
+                    var swaggerResponse = await client.EntriesClient.ExportDocumentAsync(repoId, entryId, range : "bytes=0-200, 300-400").ConfigureAwait(false);
 
                     // ASSERT
                     string result = "";
@@ -152,7 +152,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                     var client = new RepositoryApiClient(httpClient);
 
                     // ACT
-                    var swaggerResponse = await client.EntriesClient.ExportDocumentAsync(repoId, entryId, range : "bytes=0-200, 300-400");
+                    var swaggerResponse = await client.EntriesClient.ExportDocumentAsync(repoId, entryId, range : "bytes=0-200, 300-400").ConfigureAwait(false);
 
                     // ASSERT
                     string result = "";
@@ -218,7 +218,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.ExportDocumentAsync(repoId, entryId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.ExportDocumentAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Entries/ExportDocumentWithAuditReasonAsyncTest.cs
+++ b/tests/unit/Entries/ExportDocumentWithAuditReasonAsyncTest.cs
@@ -81,7 +81,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                     {
                         AuditReasonId = 1,
                         Comment = "asdf"
-                    }, range: "bytes=0-200, 300-400");
+                    }, range: "bytes=0-200, 300-400").ConfigureAwait(false);
 
                     // ASSERT
                     string result = "";
@@ -165,7 +165,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                     {
                         AuditReasonId = 1,
                         Comment = "asdf"
-                    }, range: "bytes=0-200, 300-400");
+                    }, range: "bytes=0-200, 300-400").ConfigureAwait(false);
 
                     // ASSERT
                     string result = "";
@@ -235,7 +235,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             {
                 AuditReasonId = 1,
                 Comment = "asdf"
-            }, range: "bytes=0-200, 300-400"));
+            }, range: "bytes=0-200, 300-400").ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Entries/GetDocumentContentTypeAsyncTest.cs
+++ b/tests/unit/Entries/GetDocumentContentTypeAsyncTest.cs
@@ -53,7 +53,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var swaggerResponse = await client.EntriesClient.GetDocumentContentTypeAsync(repoId, entryId);
+            var swaggerResponse = await client.EntriesClient.GetDocumentContentTypeAsync(repoId, entryId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(swaggerResponse);
@@ -108,7 +108,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetDocumentContentTypeAsync(repoId, entryId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetDocumentContentTypeAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Entries/GetDynamicFieldValuesAsyncTest.cs
+++ b/tests/unit/Entries/GetDynamicFieldValuesAsyncTest.cs
@@ -60,7 +60,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                     TemplateId = 1,
                     FieldValues = fieldValsDict
             }
-            );
+            ).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(response);
@@ -126,7 +126,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 TemplateId = 1,
                 FieldValues = new Dictionary<string, string>() { ["1"] = "2" }
             }
-            ));
+            ).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Entries/GetEntryByFullPathTest.cs
+++ b/tests/unit/Entries/GetEntryByFullPathTest.cs
@@ -67,7 +67,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetEntryByPathAsync(repoId, rootPath, fallBackToClosestAncestor);
+            var result = await client.EntriesClient.GetEntryByPathAsync(repoId, rootPath, fallBackToClosestAncestor).ConfigureAwait(false);
 
             // ASSERT   
             Assert.NotNull(result);
@@ -155,7 +155,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetEntryByPathAsync(repoId, nonExistingPath, fallBackToClosestAncestor);
+            var result = await client.EntriesClient.GetEntryByPathAsync(repoId, nonExistingPath, fallBackToClosestAncestor).ConfigureAwait(false);
 
             // ASSERT   
             Assert.NotNull(result);
@@ -226,7 +226,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryByPathAsync(repoId, rootPath, fallBackToClosestAncestor));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryByPathAsync(repoId, rootPath, fallBackToClosestAncestor).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -281,7 +281,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryByPathAsync(repoId, nonExistingPath, fallBackToClosestAncestor));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryByPathAsync(repoId, nonExistingPath, fallBackToClosestAncestor).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/Entries/GetEntryFieldsTest.cs
+++ b/tests/unit/Entries/GetEntryFieldsTest.cs
@@ -81,7 +81,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetFieldValuesAsync(repoId, entryId);
+            var result = await client.EntriesClient.GetFieldValuesAsync(repoId, entryId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -149,7 +149,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetFieldValuesAsync(repoId, entryId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetFieldValuesAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -231,7 +231,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             // ACT
             var result = await client.EntriesClient.GetFieldValuesAsync(repoId, entryId, prefer: preferHeaderValue,
                 formatValue: formatValue, culture: culture, select: selectQueryParameter, orderby: orderbyQueryParameter,
-                top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter);
+                top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/GetEntryInfoAsyncTest.cs
+++ b/tests/unit/Entries/GetEntryInfoAsyncTest.cs
@@ -61,7 +61,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetEntryAsync(repoId, entry.Id);
+            var result = await client.EntriesClient.GetEntryAsync(repoId, entry.Id).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -127,7 +127,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryAsync(repoId, entryId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -195,7 +195,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetEntryAsync(repoId, entry.Id, select: selectQueryParameter);
+            var result = await client.EntriesClient.GetEntryAsync(repoId, entry.Id, select: selectQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/GetEntryListingTest.cs
+++ b/tests/unit/Entries/GetEntryListingTest.cs
@@ -87,7 +87,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetEntryListingAsync(repoId, entryId);
+            var result = await client.EntriesClient.GetEntryListingAsync(repoId, entryId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -160,7 +160,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryListingAsync(repoId, entryId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetEntryListingAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -246,7 +246,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             // ACT
             var result = await client.EntriesClient.GetEntryListingAsync(repoId, entryId, groupByEntryType: groupByEntryType,
                 fields: new List<string>() { "field1", "field2" }, formatFields: formatFields, prefer: preferHeaderValue, culture: culture, select: selectQueryParameter,
-                orderby: orderbyQueryParameter,top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter);
+                orderby: orderbyQueryParameter,top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/GetEntryTagsTest.cs
+++ b/tests/unit/Entries/GetEntryTagsTest.cs
@@ -87,7 +87,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetTagsAssignedToEntryAsync(repoId, entryId);
+            var result = await client.EntriesClient.GetTagsAssignedToEntryAsync(repoId, entryId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -156,7 +156,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetTagsAssignedToEntryAsync(repoId, entryId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetTagsAssignedToEntryAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -239,7 +239,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             // ACT
             var result = await client.EntriesClient.GetTagsAssignedToEntryAsync(repoId, entryId, prefer: preferHeaderValue,
                 select: selectQueryParameter, orderby: orderbyQueryParameter, top: topQueryParameter,
-                skip: skipQueryParameter, count: countQueryParameter);
+                skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/GetLinkValuesFromEntryAsyncTest.cs
+++ b/tests/unit/Entries/GetLinkValuesFromEntryAsyncTest.cs
@@ -85,7 +85,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await client.EntriesClient.GetLinkValuesFromEntryAsync(repoId, entryId);
+            var response = await client.EntriesClient.GetLinkValuesFromEntryAsync(repoId, entryId).ConfigureAwait(false);
 
             var result = response.Value;
 
@@ -159,7 +159,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetLinkValuesFromEntryAsync(repoId, entryId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.GetLinkValuesFromEntryAsync(repoId, entryId).ConfigureAwait(false)).ConfigureAwait(false);
 
 
             // ASSERT
@@ -250,7 +250,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.GetLinkValuesFromEntryAsync(repoId, entryId, prefer: "Prefer", select: "select", orderby: "orderBy", top: 1, skip: 1, count: true);
+            var result = await client.EntriesClient.GetLinkValuesFromEntryAsync(repoId, entryId, prefer: "Prefer", select: "select", orderby: "orderBy", top: 1, skip: 1, count: true).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Entries/ImportDocumentTest.cs
+++ b/tests/unit/Entries/ImportDocumentTest.cs
@@ -151,7 +151,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 var client = new RepositoryApiClient(httpClient);
 
                 // ACT
-                var result = await client.EntriesClient.ImportDocumentAsync(repoId, parentEntryId, fileName, electronicDocument: electronicDocument, request: request);
+                var result = await client.EntriesClient.ImportDocumentAsync(repoId, parentEntryId, fileName, electronicDocument: electronicDocument, request: request).ConfigureAwait(false);
 
                 // ASSERT
                 Assert.NotNull(result);
@@ -252,7 +252,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 var client = new RepositoryApiClient(httpClient);
 
                 // ACT
-                var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.ImportDocumentAsync(repoId, parentEntryId, fileName, electronicDocument: electronicDocument, request: request));
+                var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.ImportDocumentAsync(repoId, parentEntryId, fileName, electronicDocument: electronicDocument, request: request).ConfigureAwait(false)).ConfigureAwait(false);
 
                 // ASSERT
                 Assert.Equal((int)statusCode, response.StatusCode);
@@ -410,7 +410,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                 var client = new RepositoryApiClient(httpClient);
 
                 // ACT
-                var result = await client.EntriesClient.ImportDocumentAsync(repoId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request);
+                var result = await client.EntriesClient.ImportDocumentAsync(repoId, parentEntryId, fileName, autoRename: true, electronicDocument: electronicDocument, request: request).ConfigureAwait(false);
 
                 // ASSERT
                 Assert.NotNull(result);

--- a/tests/unit/Entries/MoveEntryTest.cs
+++ b/tests/unit/Entries/MoveEntryTest.cs
@@ -70,7 +70,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entry.Id, request);
+            var result = await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entry.Id, request).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -146,7 +146,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entryId, request));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entryId, request).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -223,7 +223,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entry.Id, request, autoRename: true);
+            var result = await client.EntriesClient.MoveOrRenameEntryAsync(repoId, entry.Id, request, autoRename: true).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Entries/SetEntryFieldsTest.cs
+++ b/tests/unit/Entries/SetEntryFieldsTest.cs
@@ -101,7 +101,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.AssignFieldValuesAsync(repoId, entryId, fieldsToUpdate: request);
+            var result = await client.EntriesClient.AssignFieldValuesAsync(repoId, entryId, fieldsToUpdate: request).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -190,7 +190,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.AssignFieldValuesAsync(repoId, entryId, fieldsToUpdate: request));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.AssignFieldValuesAsync(repoId, entryId, fieldsToUpdate: request).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/Entries/SetLinkValuesOnEntryAsyncTest.cs
+++ b/tests/unit/Entries/SetLinkValuesOnEntryAsyncTest.cs
@@ -99,7 +99,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
                     LinkTypeId = 2,
                     CustomProperties = entryLinkInfo2.LinkProperties
                 }
-            });
+            }).ConfigureAwait(false);
         
             var result = response.Value;
 
@@ -188,7 +188,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.AssignEntryLinksAsync(repoId, entryId, new List<PutLinksRequest>()));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.AssignEntryLinksAsync(repoId, entryId, new List<PutLinksRequest>()).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Entries/SetTagValuesOnEntryAsyncTest.cs
+++ b/tests/unit/Entries/SetTagValuesOnEntryAsyncTest.cs
@@ -86,7 +86,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var response = await client.EntriesClient.AssignTagsAsync(repoId, entryId, new PutTagRequest()
             {
                 Tags = new List<string>() { tagInfo.Name, tagInfo2.Name }
-            });
+            }).ConfigureAwait(false);
             var result = response.Value;
 
             // ASSERT
@@ -194,7 +194,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.AssignTagsAsync(repoId, entryId, new PutTagRequest()
             {
                 Tags = new List<string>() { tagInfo.Name, tagInfo2.Name }
-            }));
+            }).ConfigureAwait(false)).ConfigureAwait(false);
 
 
             // ASSERT

--- a/tests/unit/Entries/WriteTemplateValueToEntryAsyncTest.cs
+++ b/tests/unit/Entries/WriteTemplateValueToEntryAsyncTest.cs
@@ -84,7 +84,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.EntriesClient.WriteTemplateValueToEntryAsync(repoId, entryId, request:request);
+            var result = await client.EntriesClient.WriteTemplateValueToEntryAsync(repoId, entryId, request:request).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -158,7 +158,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Entries
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.WriteTemplateValueToEntryAsync(repoId, entryId, request:request));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.EntriesClient.WriteTemplateValueToEntryAsync(repoId, entryId, request:request).ConfigureAwait(false)).ConfigureAwait(false);
 
             // also check the 'http' call was like we expected it
             var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/Entries/{entryId}/template");

--- a/tests/unit/FieldDefinitions/FieldDefinitionsByIdTest.cs
+++ b/tests/unit/FieldDefinitions/FieldDefinitionsByIdTest.cs
@@ -68,7 +68,7 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(repoId, fieldDefinitionId: id);
+            var result = await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(repoId, fieldDefinitionId: id).ConfigureAwait(false);
             Assert.Equal(fieldInfo1.Name, result.Name);
             Assert.Equal(fieldInfo1.Id, result.Id);
             Assert.Equal(fieldInfo1.Description, result.Description);
@@ -132,7 +132,7 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(repoId, fieldDefinitionId: id));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.FieldDefinitionsClient.GetFieldDefinitionByIdAsync(repoId, fieldDefinitionId: id).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/FieldDefinitions/FieldDefinitionsTest.cs
+++ b/tests/unit/FieldDefinitions/FieldDefinitionsTest.cs
@@ -88,7 +88,7 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(repoId);
+            var response = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(repoId).ConfigureAwait(false);
             var result = response.Value;
             Assert.Equal(2, result.Count);
             for (int i = 0; i < 2; i++)
@@ -196,7 +196,7 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            _ = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(repoId, prefer:"Prefer", select:"select", orderby:"orderby", top:1, skip:2, count:true);
+            _ = await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(repoId, prefer:"Prefer", select:"select", orderby:"orderby", top:1, skip:2, count:true).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it
@@ -246,7 +246,7 @@ namespace Laserfiche.Repository.Api.Client.Test.FieldDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(repoId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.FieldDefinitionsClient.GetFieldDefinitionsAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Laserfiche.Repository.Api.Client.Test.csproj
+++ b/tests/unit/Laserfiche.Repository.Api.Client.Test.csproj
@@ -6,6 +6,7 @@
     <Authors>Laserfiche</Authors>
     <Copyright>Apache License 2.0</Copyright>
     <PackageProjectUrl>https://www.laserfiche.com/</PackageProjectUrl>
+	<EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/unit/LinkDefinitions/LinkDefinitionsByIdTest.cs
+++ b/tests/unit/LinkDefinitions/LinkDefinitionsByIdTest.cs
@@ -56,7 +56,7 @@ namespace Laserfiche.Repository.Api.Client.Test.LinkDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(repoId, linkTypeId: id);
+            var result = await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(repoId, linkTypeId: id).ConfigureAwait(false);
             Assert.Equal(linkType1.LinkTypeId, result.LinkTypeId);
             Assert.Equal(linkType1.SourceLabel, result.SourceLabel);
             Assert.Equal(linkType1.TargetLabel, result.TargetLabel);
@@ -111,7 +111,7 @@ namespace Laserfiche.Repository.Api.Client.Test.LinkDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(repoId, linkTypeId: id));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.LinkDefinitionsClient.GetLinkDefinitionByIdAsync(repoId, linkTypeId: id).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/LinkDefinitions/LinkDefinitionsTest.cs
+++ b/tests/unit/LinkDefinitions/LinkDefinitionsTest.cs
@@ -68,7 +68,7 @@ namespace Laserfiche.Repository.Api.Client.Test.LinkDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId);
+            var response = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId).ConfigureAwait(false);
             var result = response.Value;
             Assert.Equal(2, result.Count);
             for (int i = 0; i < 2; i++)
@@ -147,7 +147,7 @@ namespace Laserfiche.Repository.Api.Client.Test.LinkDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            _ = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId, prefer: "Prefer", select: "select", orderby: "orderby", top: 1, skip: 2, count: true);
+            _ = await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId, prefer: "Prefer", select: "select", orderby: "orderby", top: 1, skip: 2, count: true).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it
@@ -197,7 +197,7 @@ namespace Laserfiche.Repository.Api.Client.Test.LinkDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.LinkDefinitionsClient.GetLinkDefinitionsAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Repositories/GetRepositoryListTest.cs
+++ b/tests/unit/Repositories/GetRepositoryListTest.cs
@@ -59,7 +59,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Repositories
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.RepositoriesClient.GetRepositoryListAsync();
+            var result = await client.RepositoriesClient.GetRepositoryListAsync().ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -117,7 +117,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Repositories
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.RepositoriesClient.GetRepositoryListAsync());
+            await Assert.ThrowsAsync<ApiException>(async () => await client.RepositoriesClient.GetRepositoryListAsync().ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Searches/CancelCloseSearchOperationTest.cs
+++ b/tests/unit/Searches/CancelCloseSearchOperationTest.cs
@@ -48,7 +48,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SearchesClient.CancelOrCloseSearchAsync(repoId, searchToken);
+            var result = await client.SearchesClient.CancelOrCloseSearchAsync(repoId, searchToken).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -102,7 +102,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.CancelOrCloseSearchAsync(repoId, searchToken));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.CancelOrCloseSearchAsync(repoId, searchToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/Searches/CreateSearchOpeartionTest.cs
+++ b/tests/unit/Searches/CreateSearchOpeartionTest.cs
@@ -56,7 +56,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SearchesClient.CreateSearchOperationAsync(repoId, searchRequest);
+            var result = await client.SearchesClient.CreateSearchOperationAsync(repoId, searchRequest).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -119,7 +119,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.CreateSearchOperationAsync(repoId, searchRequest));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.CreateSearchOperationAsync(repoId, searchRequest).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/Searches/GetSearchContextHitsTest.cs
+++ b/tests/unit/Searches/GetSearchContextHitsTest.cs
@@ -92,7 +92,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SearchesClient.GetSearchContextHitsAsync(repoId, searchToken, rowNumber);
+            var result = await client.SearchesClient.GetSearchContextHitsAsync(repoId, searchToken, rowNumber).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -167,7 +167,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.GetSearchContextHitsAsync(repoId, searchToken, rowNumber));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.GetSearchContextHitsAsync(repoId, searchToken, rowNumber).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -271,7 +271,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             // ACT
             var result = await client.SearchesClient.GetSearchContextHitsAsync(repoId, searchToken, rowNumber,
                 prefer: preferHeaderValue, select: selectQueryParameter, orderby: orderbyQueryParameter,
-                top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter);
+                top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Searches/GetSearchResultsTest.cs
+++ b/tests/unit/Searches/GetSearchResultsTest.cs
@@ -87,7 +87,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SearchesClient.GetSearchResultsAsync(repoId, searchToken);
+            var result = await client.SearchesClient.GetSearchResultsAsync(repoId, searchToken).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -160,7 +160,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.GetSearchResultsAsync(repoId, searchToken));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.GetSearchResultsAsync(repoId, searchToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -247,7 +247,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             // ACT
             var result = await client.SearchesClient.GetSearchResultsAsync(repoId, searchToken, groupByEntryType: groupByEntryType,
                 refresh: refresh, fields: new List<string>() { "field1", "field2" }, formatFields: formatFields, prefer: preferHeaderValue, culture: culture,
-                select: selectQueryParameter, orderby: orderbyQueryParameter, top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter);
+                select: selectQueryParameter, orderby: orderbyQueryParameter, top: topQueryParameter, skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/Searches/GetSearchStatusTest.cs
+++ b/tests/unit/Searches/GetSearchStatusTest.cs
@@ -60,7 +60,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken);
+            var result = await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -127,7 +127,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken);
+            var result = await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -193,7 +193,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken);
+            var result = await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -251,7 +251,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Searches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SearchesClient.GetSearchStatusAsync(repoId, searchToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/SimpleSearches/SimpleSearchTest.cs
+++ b/tests/unit/SimpleSearches/SimpleSearchTest.cs
@@ -89,7 +89,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.SimpleSearchesClient.CreateSimpleSearchOperationAsync(repoId, request: request);
+            var result = await client.SimpleSearchesClient.CreateSimpleSearchOperationAsync(repoId, request: request).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -205,7 +205,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
 
             // ACT
             var result = await client.SimpleSearchesClient.CreateSimpleSearchOperationAsync(repoId, select: "select", orderby: "orderby",
-                count: true, fields: new List<string>() { "field1", "field2" }, formatFields: true, request: request, culture: "fr");
+                count: true, fields: new List<string>() { "field1", "field2" }, formatFields: true, request: request, culture: "fr").ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -282,7 +282,7 @@ namespace Laserfiche.Repository.Api.Client.Test.SimpleSearches
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SimpleSearchesClient.CreateSimpleSearchOperationAsync(repoId, request: request));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.SimpleSearchesClient.CreateSimpleSearchOperationAsync(repoId, request: request).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/TagDefinitions/TagDefinitionsByIdTest.cs
+++ b/tests/unit/TagDefinitions/TagDefinitionsByIdTest.cs
@@ -64,7 +64,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TagDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.TagDefinitionsClient.GetTagDefinitionByIdAsync(repoId, tagInfo.Id);
+            var result = await client.TagDefinitionsClient.GetTagDefinitionByIdAsync(repoId, tagInfo.Id).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -127,7 +127,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TagDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.TagDefinitionsClient.GetTagDefinitionByIdAsync(repoId, tagDefinition));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.TagDefinitionsClient.GetTagDefinitionByIdAsync(repoId, tagDefinition).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/TagDefinitions/TagDefinitionsTest.cs
+++ b/tests/unit/TagDefinitions/TagDefinitionsTest.cs
@@ -82,7 +82,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TagDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(repoId);
+            var result = await client.TagDefinitionsClient.GetTagDefinitionsAsync(repoId).ConfigureAwait(false);
             Assert.Equal(2, result.Value.Count);
             Assert.Equal(tagInfo.Id, result.Value.ElementAt(0).Id);
             Assert.Equal(tagInfo.Description, result.Value.ElementAt(0).Description);
@@ -153,7 +153,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TagDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.TagDefinitionsClient.GetTagDefinitionsAsync(repoId));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.TagDefinitionsClient.GetTagDefinitionsAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it
@@ -240,7 +240,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TagDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            _ = await client.TagDefinitionsClient.GetTagDefinitionsAsync(repoId, prefer:"Prefer", select:"select", orderby:"orderBy",top:1, skip:1, count:true);
+            _ = await client.TagDefinitionsClient.GetTagDefinitionsAsync(repoId, prefer:"Prefer", select:"select", orderby:"orderBy",top:1, skip:1, count:true).ConfigureAwait(false);
 
             // ASSERT
             // also check the 'http' call was like we expected it

--- a/tests/unit/Tasks/CancelOperationTest.cs
+++ b/tests/unit/Tasks/CancelOperationTest.cs
@@ -46,7 +46,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Operations
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await client.TasksClient.CancelOperationAsync(repoId, operationToken);
+            await client.TasksClient.CancelOperationAsync(repoId, operationToken).ConfigureAwait(false);
 
             // also check the 'http' call was like we expected it
             var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/Tasks/{operationToken}");
@@ -97,7 +97,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Operations
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.TasksClient.CancelOperationAsync(repoId, operationToken));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.TasksClient.CancelOperationAsync(repoId, operationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // also check the 'http' call was like we expected it
             var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/Tasks/{operationToken}");

--- a/tests/unit/Tasks/GetOperationStatusTest.cs
+++ b/tests/unit/Tasks/GetOperationStatusTest.cs
@@ -56,7 +56,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Tasks
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var swaggerResponse = await client.TasksClient.GetOperationStatusAndProgressAsync(repoId, operationProgress.OperationToken);
+            var swaggerResponse = await client.TasksClient.GetOperationStatusAndProgressAsync(repoId, operationProgress.OperationToken).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal(operationProgress.OperationToken, swaggerResponse.OperationToken);
@@ -121,7 +121,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Tasks
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var progress = await client.TasksClient.GetOperationStatusAndProgressAsync(repoId, operationProgress.OperationToken);
+            var progress = await client.TasksClient.GetOperationStatusAndProgressAsync(repoId, operationProgress.OperationToken).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal(operationProgress.OperationToken, progress.OperationToken);
@@ -178,7 +178,7 @@ namespace Laserfiche.Repository.Api.Client.Test.Tasks
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            await Assert.ThrowsAsync<ApiException>(async () => await client.TasksClient.GetOperationStatusAndProgressAsync(repoId, operationToken));
+            await Assert.ThrowsAsync<ApiException>(async () => await client.TasksClient.GetOperationStatusAndProgressAsync(repoId, operationToken).ConfigureAwait(false)).ConfigureAwait(false);
 
             // also check the 'http' call was like we expected it
             var expectedUri = new Uri(baseAddress + $"v1/Repositories/{repoId}/Tasks/{operationToken}");

--- a/tests/unit/TemplateDefinitions/GetTemplateDefinitionByIdTest.cs
+++ b/tests/unit/TemplateDefinitions/GetTemplateDefinitionByIdTest.cs
@@ -60,7 +60,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionByIdAsync(repoId, templateDefinition.Id);
+            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionByIdAsync(repoId, templateDefinition.Id).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -121,7 +121,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateDefinitionByIdAsync(repoId, templateDefinitionId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateDefinitionByIdAsync(repoId, templateDefinitionId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);

--- a/tests/unit/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
+++ b/tests/unit/TemplateDefinitions/GetTemplateDefinitionFieldsByTemplateNameTest.cs
@@ -95,7 +95,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(repoId, templateDefinitioName);
+            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(repoId, templateDefinitioName).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -171,7 +171,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(repoId, templateDefinitioName));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(repoId, templateDefinitioName).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -258,7 +258,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             // ACT
             var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsByTemplateNameAsync(repoId, templateDefinitioName, prefer: preferHeaderValue,
                 select: selectQueryParameter, orderby: orderbyQueryParameter, top: topQueryParameter,
-                skip: skipQueryParameter, count: countQueryParameter);
+                skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
+++ b/tests/unit/TemplateDefinitions/GetTemplateDefinitionFieldsTest.cs
@@ -95,7 +95,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(repoId, templateDefinitionId);
+            var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(repoId, templateDefinitionId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -171,7 +171,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(repoId, templateDefinitionId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(repoId, templateDefinitionId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -258,7 +258,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             // ACT
             var result = await client.TemplateDefinitionsClient.GetTemplateFieldDefinitionsAsync(repoId, templateDefinitionId, prefer: preferHeaderValue,
                 select: selectQueryParameter, orderby: orderbyQueryParameter, top: topQueryParameter,
-                skip: skipQueryParameter, count: countQueryParameter);
+                skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);

--- a/tests/unit/TemplateDefinitions/GetTemplateDefinitionTest.cs
+++ b/tests/unit/TemplateDefinitions/GetTemplateDefinitionTest.cs
@@ -82,7 +82,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(repoId);
+            var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(repoId).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);
@@ -148,7 +148,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             var client = new RepositoryApiClient(httpClient);
 
             // ACT
-            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(repoId));
+            var response = await Assert.ThrowsAsync<ApiException>(async () => await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(repoId).ConfigureAwait(false)).ConfigureAwait(false);
 
             // ASSERT
             Assert.Equal((int)statusCode, response.StatusCode);
@@ -228,7 +228,7 @@ namespace Laserfiche.Repository.Api.Client.Test.TemplateDefinitions
             // ACT
             var result = await client.TemplateDefinitionsClient.GetTemplateDefinitionsAsync(repoId, prefer: preferHeaderValue,
                 select: selectQueryParameter, orderby: orderbyQueryParameter, top: topQueryParameter,
-                skip: skipQueryParameter, count: countQueryParameter);
+                skip: skipQueryParameter, count: countQueryParameter).ConfigureAwait(false);
 
             // ASSERT
             Assert.NotNull(result);


### PR DESCRIPTION
- Added `ConfigureAwait(false)` to all awaited async calls.
- Added `.editorconfig` in `Solution Items` to enforce `ConfigureAwait` and treat its absence as an error.