### PR TITLE
Update publish documentation step for github pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,11 +111,38 @@ jobs:
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
     steps:
-    - name: echo
-      run: echo 'hi'
+    - uses: actions/checkout@v3
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v2
+      with:
+        dotnet-version: 6.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration release
+
+    - name: set PACKAGE_VERSION environment
+      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
+
+    - name: Packaging
+      run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
+
+    - name: Publish to Nuget.org
+      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+
+    - name: Tag commit
+      uses: rickstaa/action-create-tag@v1
+      with:
+        tag: ${{ env.PACKAGE_VERSION }}
+        commit_sha: ${{ github.sha }}
+        message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 
   publish-production-package:
@@ -159,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: github-pages
-    needs: [ publish-preview-package ]
+    needs: [ publish-production-package ]
     steps:
     - name: Set DOCUMENTATION_VERSION environment variable
       run: |
@@ -173,7 +200,8 @@ jobs:
         fi
 
     - name: Print DOCUMENTATION_VERSION environment variable
-      run: echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
+      run: |
+        echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,38 +111,11 @@ jobs:
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: 6.0.x
-
-    - name: Restore dependencies
-      run: dotnet restore
-
-    - name: Build
-      run: dotnet build --no-restore --configuration release
-
-    - name: set PACKAGE_VERSION environment
-      run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}-beta-${{ github.run_id }}" >> $GITHUB_ENV
-
-    - name: Packaging
-      run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
-
-    - name: Publish to Nuget.org
-      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
-
-    - name: Tag commit
-      uses: rickstaa/action-create-tag@v1
-      with:
-        tag: ${{ env.PACKAGE_VERSION }}
-        commit_sha: ${{ github.sha }}
-        message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    - name: echo
+      run: echo 'hi'
 
 
   publish-production-package:
@@ -186,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: github-pages
-    needs: [ publish-production-package ]
+    needs: [ publish-preview-package ]
     steps:
     - name: Set DOCUMENTATION_VERSION environment variable
       run: |
@@ -200,8 +173,7 @@ jobs:
         fi
 
     - name: Print DOCUMENTATION_VERSION environment variable
-      run: |
-        echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
+      run: echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,41 +32,41 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
 
-    # - name: Run unit tests
-    #   run: dotnet test tests/unit/Laserfiche.Repository.Api.Client.Test.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
+    - name: Run unit tests
+      run: dotnet test tests/unit/Laserfiche.Repository.Api.Client.Test.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
 
-    # - name: Run integration tests
-    #   env:
-    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-    #     SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-    #     REPOSITORY_ID:  ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_3 }}
-    #     AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
-    #     TEST_HEADER: ${{ secrets.TEST_HEADER }}
-    #   run:
-    #     dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
+    - name: Run integration tests
+      env:
+        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+        SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
+        REPOSITORY_ID:  ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_3 }}
+        AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
+        TEST_HEADER: ${{ secrets.TEST_HEADER }}
+      run:
+        dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
 
-    # - name: Run integration tests on API Server
-    #   continue-on-error: true
-    #   env:
-    #     REPOSITORY_ID:  ${{ secrets.APISERVER_REPOSITORY_ID }}
-    #     APISERVER_USERNAME: ${{ secrets.APISERVER_USERNAME }}
-    #     APISERVER_PASSWORD: ${{ secrets.APISERVER_PASSWORD }}
-    #     APISERVER_REPOSITORY_API_BASE_URL: ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
-    #     AUTHORIZATION_TYPE: ${{ secrets.APISERVER_AUTHORIZATION_TYPE }}
-    #     TEST_HEADER: ${{ secrets.TEST_HEADER }}
-    #   run:
-    #     dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx"
+    - name: Run integration tests on API Server
+      continue-on-error: true
+      env:
+        REPOSITORY_ID:  ${{ secrets.APISERVER_REPOSITORY_ID }}
+        APISERVER_USERNAME: ${{ secrets.APISERVER_USERNAME }}
+        APISERVER_PASSWORD: ${{ secrets.APISERVER_PASSWORD }}
+        APISERVER_REPOSITORY_API_BASE_URL: ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+        AUTHORIZATION_TYPE: ${{ secrets.APISERVER_AUTHORIZATION_TYPE }}
+        TEST_HEADER: ${{ secrets.TEST_HEADER }}
+      run:
+        dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx"
 
-    # - name: Test Report
-    #   uses: dorny/test-reporter@v1
-    #   if: success() || failure()    # run this step even if previous step failed
-    #   with:
-    #     name: Test Results
-    #     path: '**/*.trx'
-    #     reporter: dotnet-trx
-    #     only-summary: 'false'
-    #     list-tests: 'failed'
-    #     fail-on-error: 'false'
+    - name: Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()    # run this step even if previous step failed
+      with:
+        name: Test Results
+        path: '**/*.trx'
+        reporter: dotnet-trx
+        only-summary: 'false'
+        list-tests: 'failed'
+        fail-on-error: 'false'
 
   build-documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: "1.1.2"
+  VERSION_PREFIX: '1.1.2'
+  GITHUB_PAGES_BRANCH: 'gh-pages'
 
 jobs:
   build-n-test:
@@ -107,36 +108,6 @@ jobs:
       run: rm -r ./generated_documentation
 
 
-  publish-documentation:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    environment: documentation
-    if: ${{ github.run_attempt != 1 }}
-    needs: [ build-n-test, build-documentation ] # wait for build to finish
-    steps:
-    - name: Create temporary directory
-      run: mkdir -p ./generated_documentation/html/
-
-    - name: Download a Build Artifact
-      uses: actions/download-artifact@v3.0.0
-      with:
-        name: documentation-artifact
-        path: ${{ github.workspace }}/generated_documentation/html/
-
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2 # Use your bucket region here
-
-    - name: Upload docs to S3 bucket
-      run: aws s3 sync ./generated_documentation/html/ s3://apiserver-publish-client-library-docs/${{ github.event.repository.name }}/docs/${{ github.ref_name }} --delete
-
-    - name: Delete temporary directory
-      run: rm -r ./generated_documentation/html/
-
-
   publish-preview-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -209,3 +180,51 @@ jobs:
         tag: ${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+
+  publish-documentation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: github-pages
+    needs: [ publish-production-package ]
+    steps:
+    - name: Set DOCUMENTATION_VERSION environment variable
+      run: |
+        if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
+          echo 'DOCUMENTATION_VERSION=${{ github.base_ref }}' >> $GITHUB_ENV
+        elif [[ '${{ github.ref_protected }}' == 'true' && '${{ github.ref_type }}' == 'branch' ]]; then
+          echo 'DOCUMENTATION_VERSION=${{ github.ref_name }}' >> $GITHUB_ENV
+        else
+          echo 'Unable to publish documentation for the current branch.'
+          exit 1
+        fi
+
+    - name: Print DOCUMENTATION_VERSION environment variable
+      run: |
+        echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
+
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ env.GITHUB_PAGES_BRANCH }}
+
+    - name: Delete documentation directory
+      run: rm -f -r ./docs/${{ env.DOCUMENTATION_VERSION }}
+
+    - name: Create documentation directory
+      run: mkdir -p ./docs/${{ env.DOCUMENTATION_VERSION }}
+
+    - name: Download documentation build artifact
+      uses: actions/download-artifact@v3.0.0
+      with:
+        name: documentation-artifact
+        path: ./docs/${{ env.DOCUMENTATION_VERSION }}
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4.2.3
+      with:
+        branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.DOCUMENTATION_VERSION }}-patch
+        delete-branch: true
+        title: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        commit-message: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        body: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        assignees: ${{ github.actor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,41 +32,41 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
 
-    - name: Run unit tests
-      run: dotnet test tests/unit/Laserfiche.Repository.Api.Client.Test.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
+    # - name: Run unit tests
+    #   run: dotnet test tests/unit/Laserfiche.Repository.Api.Client.Test.csproj --no-build --verbosity normal --logger "trx;LogFileName=unit-test-results.trx"
 
-    - name: Run integration tests
-      env:
-        ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
-        SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-        REPOSITORY_ID:  ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_3 }}
-        AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
-        TEST_HEADER: ${{ secrets.TEST_HEADER }}
-      run:
-        dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
+    # - name: Run integration tests
+    #   env:
+    #     ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
+    #     SERVICE_PRINCIPAL_KEY:  ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
+    #     REPOSITORY_ID:  ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_3 }}
+    #     AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
+    #     TEST_HEADER: ${{ secrets.TEST_HEADER }}
+    #   run:
+    #     dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
 
-    - name: Run integration tests on API Server
-      continue-on-error: true
-      env:
-        REPOSITORY_ID:  ${{ secrets.APISERVER_REPOSITORY_ID }}
-        APISERVER_USERNAME: ${{ secrets.APISERVER_USERNAME }}
-        APISERVER_PASSWORD: ${{ secrets.APISERVER_PASSWORD }}
-        APISERVER_REPOSITORY_API_BASE_URL: ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
-        AUTHORIZATION_TYPE: ${{ secrets.APISERVER_AUTHORIZATION_TYPE }}
-        TEST_HEADER: ${{ secrets.TEST_HEADER }}
-      run:
-        dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx"
+    # - name: Run integration tests on API Server
+    #   continue-on-error: true
+    #   env:
+    #     REPOSITORY_ID:  ${{ secrets.APISERVER_REPOSITORY_ID }}
+    #     APISERVER_USERNAME: ${{ secrets.APISERVER_USERNAME }}
+    #     APISERVER_PASSWORD: ${{ secrets.APISERVER_PASSWORD }}
+    #     APISERVER_REPOSITORY_API_BASE_URL: ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
+    #     AUTHORIZATION_TYPE: ${{ secrets.APISERVER_AUTHORIZATION_TYPE }}
+    #     TEST_HEADER: ${{ secrets.TEST_HEADER }}
+    #   run:
+    #     dotnet test tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj --no-build --verbosity normal --logger "trx;LogFileName=integration-test-self-hosted-results.trx"
 
-    - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()    # run this step even if previous step failed
-      with:
-        name: Test Results
-        path: '**/*.trx'
-        reporter: dotnet-trx
-        only-summary: 'false'
-        list-tests: 'failed'
-        fail-on-error: 'false'
+    # - name: Test Report
+    #   uses: dorny/test-reporter@v1
+    #   if: success() || failure()    # run this step even if previous step failed
+    #   with:
+    #     name: Test Results
+    #     path: '**/*.trx'
+    #     reporter: dotnet-trx
+    #     only-summary: 'false'
+    #     list-tests: 'failed'
+    #     fail-on-error: 'false'
 
   build-documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
         elif [[ '${{ github.ref_protected }}' == 'true' && '${{ github.ref_type }}' == 'branch' ]]; then
           echo 'DOCUMENTATION_VERSION=${{ github.ref_name }}' >> $GITHUB_ENV
         else
-          echo 'Unable to publish documentation for the current branch.'
+          echo '::error::Unable to publish documentation for the current branch.'
           exit 1
         fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.2 Pre-release
+## 1.1.2
 
 ### Features
 - Added `RepositoriesClient.GetSelfHostedRepositoryListAsync` method that will enable self hosted users to get their repository list without an access token.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
 # Laserfiche Repository API Client .NET
+[![NuGet version (Laserfiche.Repository.Api.Client)](https://img.shields.io/nuget/v/Laserfiche.Repository.Api.Client.svg?style=flat-square)](https://www.nuget.org/packages/Laserfiche.Repository.Api.Client)
 
 Use the Laserfiche Repository API to access data in a Laserfiche repository. Import or export files, modify the repository folder structure, read and modify templates and field values, and more.
 
-Documentation [Laserfiche Repository API](https://developer.laserfiche.com/libraries.html).
+## Documentation
+- [Laserfiche Developer Center](https://developer.laserfiche.com/)
+- [Laserfiche Repository API Client .NET Library Documentation](https://laserfiche.github.io/lf-repository-api-client-dotnet/)
+
+## Change Log
+See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/HEAD/CHANGELOG.md).
 
 ## How to contribute
-
-Technically you could use any editors you like. But it's more convenient if you are using either Visual Studio Code or Visual Studio. Here is a few useful commands for building and testing the app.
+Useful commands for building and testing the app.
 
 ### Generate the repository client
-
 1. Download the `nswag` command line tool. Instructions can be found [here](https://github.com/RicoSuter/NSwag/wiki/CommandLine).
 2. From the root directory of this Git repository, run the command `pwsh generate-client.ps1`
 
 ### Build, Test, and Package
-
 See the [.github/workflows/main.yml](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/HEAD/.github/workflows/main.yml).
-
-### Change Log
-
-See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/HEAD/CHANGELOG.md).


### PR DESCRIPTION
Changes include
- Updating the README to be consistent with other client libraries
  - See preview of it here https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/add-gh-pages/README.md
- Update step for publishing documentation in pipeline
  - I already ran the step and was able to verify it created a PR with the correct documentation changes
  https://github.com/Laserfiche/lf-repository-api-client-dotnet/pull/74
- GitHub pages site can be found at https://laserfiche.github.io/lf-repository-api-client-dotnet/docs/1.x/index.html
- Removed pre-release header from changelog for 1.1.2 since it has already been released