### PR TITLE
Use pull request bot to create auto-generated client PR

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -41,9 +41,16 @@ jobs:
     - name: Generate the client
       run: pwsh ./generate-client/generate-client.ps1 -input_folder './generate-client' -output_folder './src/Clients'
 
+    - uses: tibdex/github-app-token@v1
+      id: generate-token
+      with:
+        app_id: ${{ secrets.LF_PULL_REQUEST_BOT_APPID }}
+        private_key: ${{ secrets.LF_PULL_REQUEST_BOT_PRIVATE_KEY }}
+
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v4.2.3
       with:
+        token: ${{ steps.generate-token.outputs.token }}
         branch: ${{ github.ref_name }}-generate-${{ env.API_VERSION }}-client
         delete-branch: true
         title: "Automated update for generating the ${{ env.API_VERSION }} client by action ${{ github.run_id }}"


### PR DESCRIPTION
Update the generate-client workflow to create a pull request using the Laserfiche pull request bot. Currently the workflow creates a pull request using the default github-actions bot. A problem with this bot is that it will not trigger other workflows when it create a PR for us, so our build and test pipelines do not run. See more about this [here](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs). The Laserfiche pull request bot is a GitHub App, so it can get around this problem

See an example of the PR created by the bot [here ](https://github.com/Laserfiche/lf-repository-api-client-dotnet/pull/80)