### PR TITLE
Prefix tag name with v1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -142,7 +142,7 @@ jobs:
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1
       with:
-        tag: ${{ env.PACKAGE_VERSION }}
+        tag: v1-${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -179,7 +179,7 @@ jobs:
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1
       with:
-        tag: ${{ env.PACKAGE_VERSION }}
+        tag: v1-${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
In another [PR](https://github.com/Laserfiche/lf-repository-api-client-dotnet/pull/91), we distinguish the tag name of v2. It's better if v1 can distinguish it from v2 by itself, so this PR is to prefix a "v1" in front all future v1 tags.