### PR TITLE
[gh-pages] Add generic index.html for each api version

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url='/lf-repository-api-client-dotnet/docs/v1/1.x/index.html'" />
+    <meta http-equiv="refresh" content="0; url='/lf-repository-api-client-dotnet/docs/v1/index.html'" />
 </head>
 
 <body>

--- a/docs/1.x/index.html
+++ b/docs/1.x/index.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url='/lf-repository-api-client-dotnet/docs/v1/1.x/index.html'" />
+    <meta http-equiv="refresh" content="0; url='/lf-repository-api-client-dotnet/docs/v1/index.html'" />
 </head>
 
 <body>

--- a/docs/v1/index.html
+++ b/docs/v1/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <!-- This page should always redirect to the highest major version index.html for the current api version -->
+    <meta http-equiv="refresh" content="0; url='/lf-repository-api-client-dotnet/docs/v1/1.x/index.html'" />
+</head>
+
+<body>
+</body>
+
+</html>

--- a/docs/v2/index.html
+++ b/docs/v2/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <!-- This page should always redirect to the highest major version index.html for the current api version -->
+    <meta http-equiv="refresh" content="0; url='/lf-repository-api-client-dotnet/docs/v2/1.x/index.html'" />
+</head>
+
+<body>
+</body>
+
+</html>


### PR DESCRIPTION
- add generic index.html for each api version so that we can create links to https://laserfiche.github.io/lf-repository-api-client-dotnet/docs/v2/index.html and automatically get redirected to the https://laserfiche.github.io/lf-repository-api-client-dotnet/docs/v2/1.x/index.html which is the highest major version of the v2 client lib.