### PR TITLE
Additional changes for v1 branch restructure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  API_VERSION: 'v2'
   VERSION_PREFIX: '1.1.3'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 
@@ -142,7 +143,7 @@ jobs:
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1
       with:
-        tag: v1-${{ env.PACKAGE_VERSION }}
+        tag: ${{ env.API_VERSION }}-${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -179,7 +180,7 @@ jobs:
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1
       with:
-        tag: v1-${{ env.PACKAGE_VERSION }}
+        tag: ${{ env.API_VERSION }}-${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -192,41 +193,36 @@ jobs:
     steps:
     - name: Set DOCUMENTATION_VERSION environment variable
       run: |
-        if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-          echo 'DOCUMENTATION_VERSION=${{ github.base_ref }}' >> $GITHUB_ENV
-        elif [[ '${{ github.ref_protected }}' == 'true' && '${{ github.ref_type }}' == 'branch' ]]; then
-          echo 'DOCUMENTATION_VERSION=${{ github.ref_name }}' >> $GITHUB_ENV
-        else
-          echo '::error::Unable to publish documentation for the current branch.'
-          exit 1
-        fi
-
+        version_prefix=${{ env.VERSION_PREFIX }}
+        major_version=${version_prefix%%.*}
+        documentation_version=$major_version.x
+        echo $documentation_version
+        echo DOCUMENTATION_VERSION=$documentation_version >> $GITHUB_ENV
     - name: Print DOCUMENTATION_VERSION environment variable
       run: |
-        echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
-
+        echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }}.'
     - uses: actions/checkout@v3
       with:
         ref: ${{ env.GITHUB_PAGES_BRANCH }}
 
     - name: Delete documentation directory
-      run: rm -f -r ./docs/${{ env.DOCUMENTATION_VERSION }}
+      run: rm -f -r ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
     - name: Create documentation directory
-      run: mkdir -p ./docs/${{ env.DOCUMENTATION_VERSION }}
+      run: mkdir -p ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
     - name: Download documentation build artifact
       uses: actions/download-artifact@v3.0.0
       with:
         name: documentation-artifact
-        path: ./docs/${{ env.DOCUMENTATION_VERSION }}
+        path: ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
-    - name: Create pull request
+    - name: Create a pull request
       uses: peter-evans/create-pull-request@v4.2.3
       with:
-        branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.DOCUMENTATION_VERSION }}-patch
+        branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.API_VERSION }}-${{ env.DOCUMENTATION_VERSION }}-patch
         delete-branch: true
-        title: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
-        commit-message: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
-        body: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        title: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        commit-message: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+        body: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
         assignees: ${{ github.actor }}

--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@ Use the Laserfiche Repository API to access data in a Laserfiche repository. Imp
 
 ## Documentation
 - [Laserfiche Developer Center](https://developer.laserfiche.com/)
-- [Laserfiche Repository API Client .NET Library Documentation](https://laserfiche.github.io/lf-repository-api-client-dotnet/)
+- [Documentation](https://laserfiche.github.io/lf-repository-api-client-dotnet/docs/v1/index.html) for the `Laserfiche.Repository.Api.Client` NuGet package used to access the v1 Laserfiche Repository APIs.
 
 ## Changelog
-See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/HEAD/CHANGELOG.md).
+See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/v1/CHANGELOG.md).
 
 ## How to contribute
 Useful commands for building and testing the app.
 
 ### Generate the repository client
-See the [.github/workflows/generate-client.yml](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/HEAD/.github/workflows/generate-client.yml).
+See the [.github/workflows/generate-client.yml](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/v1/.github/workflows/generate-client.yml).
 
 ### Build, test, and package
-See the [.github/workflows/main.yml](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/HEAD/.github/workflows/main.yml).
+See the [.github/workflows/main.yml](https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/v1/.github/workflows/main.yml).
 
 #### Branches
 The v1 branch stores client code for the Laserfiche Repository API v1; the v2 branch stores client code for the Laserfiche Repository API v2.

--- a/doxygen/doxygen.conf
+++ b/doxygen/doxygen.conf
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "lf-repository-api-client-dotnet"
+PROJECT_NAME           = "Laserfiche.Repository.Api.Client"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/src/Laserfiche.Repository.Api.Client.csproj
+++ b/src/Laserfiche.Repository.Api.Client.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>1.1.3</Version>
     <Authors>Laserfiche</Authors>
-    <Description>.NET API that enables easy and secure access to Laserfiche Repository.</Description>
+    <Description>The .NET Laserfiche Repository API client library for accessing the v1 Laserfiche Repository APIs.</Description>
     <Copyright>Copyright 2022 Laserfiche</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
- Update the publish documentation pipeline step to include the api version (ie v1, v2) in the folder path
- Update the README to include v1 specific links
- Use the title of the package name instead of the repository name in the doxygen generated documentation