### PR TITLE
Update constructor for Fileparameter class

### DIFF
--- a/.github/workflows/generate-client.yml
+++ b/.github/workflows/generate-client.yml
@@ -8,7 +8,7 @@ on:
         description: 'URL to download the swagger schema.'
         required: true
         type: string
-        default: 'https://api.laserfiche.com/repository/swagger/v1/swagger.json'
+        default: 'https://api.laserfiche.com/repository/swagger/v2/swagger.json'
 
 jobs:
   generate-client:

--- a/generate-client/download_swagger.py
+++ b/generate-client/download_swagger.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Downloads a swagger file')
     parser.add_argument('--swagger-url',
                         help='The url to download the swagger file.',
-                        default='https://api.laserfiche.com/repository/swagger/v1/swagger.json')
+                        default='https://api.laserfiche.com/repository/swagger/v2/swagger.json')
     parser.add_argument('--swagger-override-filepath',
                         help='Optional json file with override values to replace in the swagger file.')
     parser.add_argument('--output-filepath',

--- a/generate-client/nswag.json
+++ b/generate-client/nswag.json
@@ -32,6 +32,7 @@
         "System.Threading.Tasks"
       ],
       "excludedTypeNames": [
+        "FileParameter",
         "ProblemDetails"
       ],
       "generateClientInterfaces": true,
@@ -43,10 +44,8 @@
       "arrayType": "IList",
       "arrayInstanceType": "List",
       "templateDirectory": "nswag",
-      "wrapResponses": true,
-      "wrapResponseMethods": [
-        "EntriesClient.GetDocumentContentType"
-      ],
+      "wrapResponses": false,
+      "wrapResponseMethods": [],
       "responseClass": "HttpResponseHead"
     }
   }

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -13897,61 +13897,6 @@ namespace Laserfiche.Repository.Api.Client
 
     }
 
-    [GeneratedCode("NSwag", "13.19.0.0 (NJsonSchema v10.9.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class FileParameter
-    {
-        public FileParameter(Stream data)
-            : this (data, null, null)
-        {
-        }
-
-        public FileParameter(Stream data, string fileName)
-            : this (data, fileName, null)
-        {
-        }
-
-        public FileParameter(Stream data, string fileName, string contentType)
-        {
-            Data = data;
-            FileName = fileName;
-            ContentType = contentType;
-        }
-
-        public Stream Data { get; private set; }
-
-        public string FileName { get; private set; }
-
-        public string ContentType { get; private set; }
-    }
-
-
-    [GeneratedCode("NSwag", "13.19.0.0 (NJsonSchema v10.9.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class HttpResponseHead
-    {
-        public int StatusCode { get; private set; }
-
-        public IReadOnlyDictionary<string, IEnumerable<string>> Headers { get; private set; }
-
-        public HttpResponseHead(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers)
-        {
-            StatusCode = statusCode;
-            Headers = headers;
-        }
-    }
-
-    [GeneratedCode("NSwag", "13.19.0.0 (NJsonSchema v10.9.0.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class HttpResponseHead<TResult> : HttpResponseHead
-    {
-        public TResult Result { get; private set; }
-
-        public HttpResponseHead(int statusCode, IReadOnlyDictionary<string, IEnumerable<string>> headers, TResult result)
-            : base(statusCode, headers)
-        {
-            Result = result;
-        }
-    }
-
-
 
 }
 

--- a/src/Clients/RepositoryClientsPartial.cs
+++ b/src/Clients/RepositoryClientsPartial.cs
@@ -18,6 +18,15 @@ namespace Laserfiche.Repository.Api.Client
         /// Constructor for representing a file to be uploaded.
         /// </summary>
         /// <param name="data">The file data.</param>
+        /// <param name="fileName">The name of the file to be uploaded. The file extension in the name will be used as the file extension of the imported entry. For common file extensions, the mime type may be derived from the file extension.</param>
+        public FileParameter(Stream data, string fileName) : this(data, fileName, null)
+        {
+        }
+
+        /// <summary>
+        /// Constructor for representing a file to be uploaded.
+        /// </summary>
+        /// <param name="data">The file data.</param>
         /// <param name="fileName">The name of the file to be uploaded. The file extension in the name will be used as the extension of the imported entry.</param>
         /// <param name="mimeType">The mime-type of the file to be uploaded.</param>
         public FileParameter(Stream data, string fileName, string mimeType)

--- a/src/Clients/RepositoryClientsPartial.cs
+++ b/src/Clients/RepositoryClientsPartial.cs
@@ -3,11 +3,51 @@ using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.CodeDom.Compiler;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 
 namespace Laserfiche.Repository.Api.Client
 {
+    /// <summary>
+    /// Represents a file to be uploaded.
+    /// </summary>
+    public partial class FileParameter
+    {
+        /// <summary>
+        /// Constructor for representing a file to be uploaded.
+        /// </summary>
+        /// <param name="data">The file data.</param>
+        /// <param name="fileName">The name of the file to be uploaded. The file extension in the name will be used as the extension of the imported entry.</param>
+        /// <param name="mimeType">The mime-type of the file to be uploaded.</param>
+        public FileParameter(Stream data, string fileName, string mimeType)
+        {
+            Data = data;
+            FileName = fileName;
+            MimeType = mimeType;
+        }
+
+        /// <summary>
+        /// The file data.
+        /// </summary>
+        public Stream Data { get; private set; }
+
+        /// <summary>
+        /// The name of the file to be uploaded. The file extension in the name will be used as the extension of the imported entry.
+        /// </summary>
+        public string FileName { get; private set; }
+
+        /// <summary>
+        /// The mime-type of the file to be uploaded.
+        /// </summary>
+        public string MimeType { get; private set; }
+
+        internal string ContentType
+        {
+            get { return MimeType; }
+        }
+    }
+
     #region inheritance
     [JsonConverter(typeof(JsonInheritanceConverter), "entryType")]
     [JsonInheritance("Document", typeof(Document))]

--- a/tests/integration/Entries/ImportEntryTest.cs
+++ b/tests/integration/Entries/ImportEntryTest.cs
@@ -35,7 +35,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         {
             string fileLocation = TempPath + "test.pdf";
             fileStream = File.OpenRead(fileLocation);
-            return new FileParameter(fileStream, "test", "application/pdf");
+            return new FileParameter(fileStream, "test.pdf", "application/pdf");
         }
 
         [TestMethod]


### PR DESCRIPTION
- Remove `FileParameter` class from being auto-generated to remove the constructor from the `FileParameter` class that accepts a single Stream argument as it can cause import without correct extension and mime type. 
  - Added documentation to `FileParameter` class to explain usage. 
  - Renamed `ContentType` parameter to `MimeType` to be consistent with the [CreateMultipartUploadUrlsRequest](https://laserfiche.github.io/lf-repository-api-client-dotnet/docs/v2/1.x/class_laserfiche_1_1_repository_1_1_api_1_1_client_1_1_create_multipart_upload_urls_request.html) class
- Update nswag code generator settings to remove unnecessary `HttpResponseHead` class from being generated
- Fix link in pipeline to use v2 instead of v1