### PR TITLE
test(integration): un-Ignore WritePage tests; switch to V2 2.1.0-beta-25349096326 preview package

### DIFF
--- a/tests/integration/Entries/WritePageImageTest.cs
+++ b/tests/integration/Entries/WritePageImageTest.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
 {
     [TestClass]
-    [Ignore("PUT /Document/Pages/{n} requires the WritePage path-segment routing bridge (server middleware + NSwag processor). Re-enable once that change ships to the integration-test environment.")]
     public class WritePageTest : BaseTest
     {
         int createdEntryId;

--- a/tests/integration/Entries/WritePageTextTest.cs
+++ b/tests/integration/Entries/WritePageTextTest.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
 {
     [TestClass]
-    [Ignore("PUT /Document/Pages/{n} requires the WritePage path-segment routing bridge (server middleware + NSwag processor). Re-enable once that change ships to the integration-test environment.")]
     public class WritePageTextTest : BaseTest
     {
         int createdEntryId;

--- a/tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj
+++ b/tests/integration/Laserfiche.Repository.Api.Client.IntegrationTest.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Laserfiche.Repository.Api.Client.csproj" />
+    <PackageReference Include="Laserfiche.Repository.Api.Client.V2" Version="2.1.0-beta-25349096326" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Un-Ignores `WritePageTest` and `WritePageTextTest` and switches the integration test project to the `Laserfiche.Repository.Api.Client.V2 2.1.0-beta-25349096326` preview package.

The `[Ignore]` reason on both classes — *"PUT /Document/Pages/{n} requires the WritePage path-segment routing bridge..."* — is obsolete. The routing bridge was replaced by the EDM-containment refactor (`site-api-repository` !169468 / commit `7337ca6`) and is live in the integration-test environment.

## Changes

3 files: drop `[Ignore]` on both test classes; swap `ProjectReference` for `PackageReference` (V2 `2.1.0-beta-25349096326`).

## Verification

`dotnet build` clean. CI will validate the un-Ignored tests against cloud + self-hosted.