### PR TITLE
Regen client for Field Definition Admin endpoints (PRD 6.3.A)

### DIFF
--- a/generate-client/swagger.json
+++ b/generate-client/swagger.json
@@ -1528,6 +1528,237 @@
         }
       }
     },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Properties": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Gets the extended-properties bag for a field definition.",
+        "description": "- The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the extended properties for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldPropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Partially updates the extended-properties bag for a field definition.",
+        "description": "- Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.\n- Empty set and empty remove is a no-op and returns the current bag.\n- Returns the full property bag after the change.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateFieldProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFieldPropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the extended properties for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldPropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v2/Repositories/{repositoryId}/LinkDefinitions": {
       "get": {
         "tags": [
@@ -10639,6 +10870,14 @@
             "items": {
               "type": "string"
             }
+          },
+          "properties": {
+            "type": "object",
+            "description": "Initial extended properties (opaque WebDAV-keyed bag) to persist atomically with the field.\nUse the dedicated /FieldDefinitions/{id}/Properties endpoints to manage after creation.\nFor list fields, this is where the admin UI stores sort order, add-blank, add-Other,\ndisplay-as-dropdown, and similar UI-display options.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         }
       },
@@ -10843,6 +11082,44 @@
             "type": "integer",
             "description": "The count of entries currently using this field.",
             "format": "int32"
+          }
+        }
+      },
+      "FieldPropertiesResponse": {
+        "type": "object",
+        "description": "Response body for the extended-properties bag on a field definition. The bag is opaque:\nkeys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field\nsort order, add-blank, add-Other, display-as), and values are strings the UI interprets.",
+        "additionalProperties": false,
+        "properties": {
+          "properties": {
+            "type": "object",
+            "description": "The full set of extended properties currently set on the field.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UpdateFieldPropertiesRequest": {
+        "type": "object",
+        "description": "Request body for partially updating the extended-properties bag on a field definition.\nEntries in Set are written (creating or overwriting). Entries in Remove\nare deleted. Properties not mentioned in either are left unchanged.",
+        "additionalProperties": false,
+        "properties": {
+          "set": {
+            "type": "object",
+            "description": "Properties to set. Keys absent here are not modified.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "remove": {
+            "type": "array",
+            "description": "Property keys to remove. Keys not currently set are ignored.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/generate-client/swagger.json
+++ b/generate-client/swagger.json
@@ -571,6 +571,218 @@
             }
           }
         }
+      },
+      "patch": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Updates properties of an existing field definition (partial update).",
+        "description": "- Partial-update merge semantics. null = leave unchanged; \"\" = clear a string property.\n- FieldType cannot be changed via this endpoint \u2014 use the dedicated ChangeFieldType endpoint.\n- ListValues cannot be changed via this endpoint \u2014 use the dedicated ListValues endpoints.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateFieldDefinition",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition to update.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The properties to change. Only non-null properties are applied; null leaves the property unchanged. Empty string clears a string property.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFieldDefinitionRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Deletes a field definition from the repository.",
+        "description": "- Deletes the specified field definition. Behavior when the field is referenced by templates or assigned to entries mirrors the underlying repository server response \u2014 if rejected by the server, the response surfaces the server error.\n- Required OAuth scope: repository.Write",
+        "operationId": "DeleteFieldDefinition",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition to delete.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the field definition."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v2/Repositories/{repositoryId}/FieldDefinitions": {
@@ -707,6 +919,584 @@
           },
           "404": {
             "description": "Not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Creates a new field definition in the repository.",
+        "description": "- Creates a new metadata field definition with the supplied core attributes, flags, and (optionally) initial list values for list-backed fields.\n- Names must be unique within the repository; duplicate-name failures return 400.\n- Required OAuth scope: repository.Write",
+        "operationId": "CreateFieldDefinition",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The field definition to create. Name and FieldType are required.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFieldDefinitionRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Returns the list values configured on a list-backed field definition.",
+        "description": "- Returns the field's configured list-item values in repository-configured order.\n- Applies only to list-backed fields; non-list fields return an empty array.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldListValues",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the list values for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListValuesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Replaces the list values for a list-backed field definition.",
+        "description": "- Replaces the field's full list-item set wholesale. No partial add/remove endpoints are exposed.\n- Duplicates and empty-string values are rejected with 400.\n- Required OAuth scope: repository.Write",
+        "operationId": "ReplaceFieldListValues",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The new list of values. Order is preserved. Empty array clears the list.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReplaceListValuesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully replaced the list values for the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListValuesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ContainingTemplates": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Returns the templates that contain the specified field definition.",
+        "description": "- Lists template definitions that include the specified field. Useful before performing destructive operations on the field.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldContainingTemplates",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 5
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "description": "Indicates whether the total count of items within a collection are returned in the result.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 6
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the templates that contain the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TemplateDefinition"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/AssignedEntryCount": {
+      "get": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Returns the count of entries that have a value assigned for the specified field definition.",
+        "description": "- Useful for impact analysis before performing destructive operations such as type changes or deletion.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetFieldAssignedEntryCount",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the count of entries assigned to the field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignedEntryCountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -2111,7 +2901,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4047,7 +4837,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4158,7 +4948,7 @@
           "Entries"
         ],
         "summary": "Updates a document entry's electronic document and/or metadata from previously uploaded parts.",
-        "description": "- Updates a document entry from previously uploaded parts. The parts are assembled server-side into a single file that is then applied to the existing document.\n- The uploadId is obtained from the CreateMultipartUploadUrls response. The partETags are the ETag values returned by S3 when uploading each file chunk to the pre-signed upload URLs, and should be provided in the order of their associated upload URLs.\n- Use this endpoint when the file exceeds the upload size or time limits of the synchronous PATCH /Document endpoint.\n- The assembled file is applied as either the electronic document or image pages, following the same rules as the synchronous PATCH /Document:\n  - If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if `importAsElectronicDocument=true`, the file replaces the existing electronic document. For supported edoc formats, `pdfOptions.generatePages` additionally produces server-rendered image pages, and `pdfOptions.generateText` triggers text extraction from the document (or OCR when the source is image-based).\n  - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.\n- If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.\n- Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.\n- `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.\n- Required OAuth scope: repository.Write",
+        "description": "- Updates a document entry from previously uploaded parts. The parts are assembled server-side into a single file that is then applied to the existing document.\n- The uploadId is obtained from the CreateMultipartUploadUrls response. The partETags are the ETag values returned by S3 when uploading each file chunk to the pre-signed upload URLs, and should be provided in the order of their associated upload URLs.\n- Use this endpoint when the file exceeds the upload size or time limits of the synchronous PATCH /Document endpoint.\n- The assembled file is applied as either the electronic document or image pages, following the same rules as the synchronous PATCH /Document:\n  - If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if `importAsElectronicDocument=true`, the file replaces the existing electronic document. For supported edoc formats, `pdfOptions.generatePages` additionally produces server-rendered image pages, and `pdfOptions.generateText` triggers text extraction from the document (or OCR when the source is image-based).\n  - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.\n- If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.\n- Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.\n- `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.\n- Required OAuth scope: repository.Write",
         "operationId": "UpdateDocumentUploadedParts",
         "parameters": [
           {
@@ -4591,7 +5381,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4736,7 +5526,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4834,8 +5624,8 @@
         "tags": [
           "Entries"
         ],
-        "summary": "Returns page information for pages in a document.",
-        "description": "- Returns a list of page properties including image dimensions, rotation angle, and content flags.\n- Optional parameter: pageRange (default empty). If no pageRange is specified, information for all pages is returned. The value should be a comma-separated string which contains non-overlapping single values, or page ranges. Ex: \"1,2,3\", \"1-3,5\", \"2-7,10-12.\"\n- Required OAuth scope: repository.Read",
+        "summary": "Returns page information for the pages of a document.",
+        "description": "- Returns a list of page properties including image dimensions, rotation angle, and content flags.\n- Pages are returned in ascending pageNumber order; that order is fixed and not configurable.\n- Default page size: 150. Allowed OData query options: Select | Count | SkipToken | Top | Prefer.\n- pageRange filters which pages are returned before paging is applied. Combine pageRange with $top/$skiptoken to paginate within a known range.\n- Required OAuth scope: repository.Read",
         "operationId": "ListPageInfos",
         "parameters": [
           {
@@ -4862,12 +5652,23 @@
           {
             "name": "pageRange",
             "in": "query",
-            "description": "The pages to retrieve information for.",
+            "description": "Optional comma-separated page numbers and ranges (e.g., \"1,3-5,8-10\"). Ranges must not overlap. When omitted, all pages are returned (subject to paging).",
             "schema": {
               "type": "string",
               "nullable": true
             },
             "x-position": 3
+          },
+          {
+            "name": "Prefer",
+            "x-originalName": "prefer",
+            "in": "header",
+            "description": "An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
           },
           {
             "name": "$select",
@@ -4877,15 +5678,15 @@
               "type": "string",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 5
           },
           {
-            "name": "$orderby",
+            "name": "$top",
             "in": "query",
-            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "description": "Limits the number of items returned from a collection. The maximum value is 150.",
             "schema": {
-              "type": "string",
-              "nullable": true
+              "type": "integer",
+              "format": "int32"
             },
             "x-position": 6
           },
@@ -4901,14 +5702,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Successfully retrieved page information for the specified pages in the document.",
+            "description": "Successfully retrieved a paged listing of page information for the document.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PageInfoResponse"
-                  }
+                  "$ref": "#/components/schemas/PageInfoCollectionResponse"
                 }
               }
             }
@@ -6427,7 +7225,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6540,7 +7338,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6646,7 +7444,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6740,6 +7538,26 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict. The request could not be completed due to the current state of the resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "423": {
+            "description": "Entry is locked",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -6751,7 +7569,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6888,7 +7706,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -7004,6 +7822,16 @@
               }
             }
           },
+          "423": {
+            "description": "Entry is locked",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -7015,7 +7843,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -7130,7 +7958,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -9496,6 +10324,26 @@
             "type": "string",
             "description": "The custom format pattern for fields that are configured to use a custom format.",
             "nullable": true
+          },
+          "isIndexed": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the field is indexed for searching."
+          },
+          "isIndexedForReporting": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the field is indexed for reporting."
+          },
+          "warnIfBlank": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the user should be warned when leaving the field blank."
+          },
+          "hideListValues": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the field's list values should be hidden in the UI.\nApplies only to list-backed fields."
+          },
+          "autoExtract": {
+            "type": "boolean",
+            "description": "A boolean indicating whether values for this field can be automatically extracted by AI/OCR services."
           }
         }
       },
@@ -9680,6 +10528,321 @@
             "items": {
               "$ref": "#/components/schemas/FieldDefinition"
             }
+          }
+        }
+      },
+      "CreateFieldDefinitionRequest": {
+        "type": "object",
+        "description": "Request body for creating a new field definition. Name and FieldType are required;\nall other properties are optional and fall back to repository defaults when omitted.",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "fieldType"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the field. Required. Must be unique within the repository."
+          },
+          "fieldType": {
+            "description": "The type of the field. Required. Cannot be changed via UpdateFieldDefinition;\nuse the ChangeFieldType endpoint to convert between types.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldType"
+              }
+            ]
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the field.",
+            "nullable": true
+          },
+          "length": {
+            "type": "integer",
+            "description": "The maximum length of the field for variable-length data types.",
+            "format": "int32",
+            "nullable": true
+          },
+          "defaultValue": {
+            "type": "string",
+            "description": "The default value applied to entries assigned to a template containing this field.",
+            "nullable": true
+          },
+          "format": {
+            "description": "The display format for the field. Defaults to None when omitted.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldFormat"
+              }
+            ]
+          },
+          "formatPattern": {
+            "type": "string",
+            "description": "The custom format pattern. Only meaningful when Format is set to a value that supports custom patterns.",
+            "nullable": true
+          },
+          "currency": {
+            "type": "string",
+            "description": "The currency for numeric fields when Format is Currency.",
+            "nullable": true
+          },
+          "constraint": {
+            "type": "string",
+            "description": "A validation constraint expression for values stored in this field.",
+            "nullable": true
+          },
+          "constraintError": {
+            "type": "string",
+            "description": "The error message returned when the constraint is violated.",
+            "nullable": true
+          },
+          "isMultiValue": {
+            "type": "boolean",
+            "description": "Whether the field supports multiple values.",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required on entries assigned to a template containing it.",
+            "nullable": true
+          },
+          "isIndexed": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for searching.",
+            "nullable": true
+          },
+          "isIndexedForReporting": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for reporting.",
+            "nullable": true
+          },
+          "warnIfBlank": {
+            "type": "boolean",
+            "description": "Whether the user should be warned when leaving the field blank.",
+            "nullable": true
+          },
+          "hideListValues": {
+            "type": "boolean",
+            "description": "Whether list values should be hidden in the UI. Applies only to list-backed fields.",
+            "nullable": true
+          },
+          "autoExtract": {
+            "type": "boolean",
+            "description": "Whether values for this field can be automatically extracted by AI/OCR services.",
+            "nullable": true
+          },
+          "listValues": {
+            "type": "array",
+            "description": "Initial list values to populate. Applies only when FieldType is List.\nOrder is preserved. Use the dedicated ListValues endpoints to manage list values after creation.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UpdateFieldDefinitionRequest": {
+        "type": "object",
+        "description": "Request body for partial-update of an existing field definition. Every property is optional.\nnull = leave the property unchanged.\nEmpty string (\"\") on a string property = clear the value.\nFieldType cannot be changed via this endpoint \u2014 use the ChangeFieldType endpoint.\nListValues cannot be changed via this endpoint \u2014 use the dedicated ListValues endpoints.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The new name of the field. Must be unique within the repository.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the field.",
+            "nullable": true
+          },
+          "length": {
+            "type": "integer",
+            "description": "The maximum length of the field for variable-length data types.",
+            "format": "int32",
+            "nullable": true
+          },
+          "defaultValue": {
+            "type": "string",
+            "description": "The default value applied to entries assigned to a template containing this field.",
+            "nullable": true
+          },
+          "format": {
+            "description": "The display format for the field.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldFormat"
+              }
+            ]
+          },
+          "formatPattern": {
+            "type": "string",
+            "description": "The custom format pattern.",
+            "nullable": true
+          },
+          "currency": {
+            "type": "string",
+            "description": "The currency for numeric fields when Format is Currency.",
+            "nullable": true
+          },
+          "constraint": {
+            "type": "string",
+            "description": "A validation constraint expression for values stored in this field.",
+            "nullable": true
+          },
+          "constraintError": {
+            "type": "string",
+            "description": "The error message returned when the constraint is violated.",
+            "nullable": true
+          },
+          "isMultiValue": {
+            "type": "boolean",
+            "description": "Whether the field supports multiple values.",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required on entries assigned to a template containing it.",
+            "nullable": true
+          },
+          "isIndexed": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for searching.",
+            "nullable": true
+          },
+          "isIndexedForReporting": {
+            "type": "boolean",
+            "description": "Whether the field is indexed for reporting.",
+            "nullable": true
+          },
+          "warnIfBlank": {
+            "type": "boolean",
+            "description": "Whether the user should be warned when leaving the field blank.",
+            "nullable": true
+          },
+          "hideListValues": {
+            "type": "boolean",
+            "description": "Whether list values should be hidden in the UI. Applies only to list-backed fields.",
+            "nullable": true
+          },
+          "autoExtract": {
+            "type": "boolean",
+            "description": "Whether values for this field can be automatically extracted by AI/OCR services.",
+            "nullable": true
+          }
+        }
+      },
+      "ListValuesResponse": {
+        "type": "object",
+        "description": "Response containing the list values of a field definition, in the order configured on the server.",
+        "additionalProperties": false,
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "The ordered list of list-item values.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ReplaceListValuesRequest": {
+        "type": "object",
+        "description": "Request body for replacing the list values of a list-backed field definition.\nThe provided values replace the field's full list-item set wholesale, preserving the supplied order.\nAn empty array clears the list.",
+        "additionalProperties": false,
+        "required": [
+          "values"
+        ],
+        "properties": {
+          "values": {
+            "type": "array",
+            "description": "The ordered list of list-item values to apply. Duplicates and empty strings are rejected with 400.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "TemplateDefinition": {
+        "type": "object",
+        "description": "Represents a template definition.",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The ID of the template definition.",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the template definition.",
+            "nullable": true
+          },
+          "displayName": {
+            "type": "string",
+            "description": "The localized name of the template definition.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the template definition.",
+            "nullable": true
+          },
+          "color": {
+            "description": "The color assigned to the template definition.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LFColor"
+              }
+            ]
+          },
+          "fieldCount": {
+            "type": "integer",
+            "description": "The number of field definitions assigned to the template definition.",
+            "format": "int32"
+          }
+        }
+      },
+      "LFColor": {
+        "type": "object",
+        "description": "Represents an RGB color value with alpha channel.",
+        "additionalProperties": false,
+        "properties": {
+          "a": {
+            "type": "integer",
+            "description": "The alpha channel component, from 0-255.",
+            "format": "byte"
+          },
+          "r": {
+            "type": "integer",
+            "description": "The red channel component, from 0-255.",
+            "format": "byte"
+          },
+          "g": {
+            "type": "integer",
+            "description": "The green channel component, from 0-255.",
+            "format": "byte"
+          },
+          "b": {
+            "type": "integer",
+            "description": "The blue channel component from 0-255.",
+            "format": "byte"
+          }
+        }
+      },
+      "AssignedEntryCountResponse": {
+        "type": "object",
+        "description": "The number of entries that have a value assigned for a given field definition.",
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "The count of entries currently using this field.",
+            "format": "int32"
           }
         }
       },
@@ -10634,12 +11797,12 @@
               },
               "lockedBy": {
                 "type": "string",
-                "description": "The account name of the persistent lock holder. Null if the document is not locked.",
+                "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the persistent lock holder. Null if the document is not locked.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.\nTo test whether the current authenticated user holds the lock, use IsLockedByAnotherUser; it compares stable principal identifiers internally.",
                 "nullable": true
               },
               "isLockedByAnotherUser": {
                 "type": "boolean",
-                "description": "A boolean indicating if the document is locked by a user other than the authenticated user.\nFalse if the document is not locked or is locked by the authenticated user.\nOnly populated on single-entry GET, not in listing results."
+                "description": "A boolean indicating if the document is locked by a user other than the authenticated user.\nFalse if the document is not locked or is locked by the authenticated user.\nComputed from a stable principal identifier comparison, not from LockedBy.\nOnly populated on single-entry GET, not in listing results."
               },
               "currentVersion": {
                 "type": "integer",
@@ -10648,12 +11811,12 @@
               },
               "checkedOutBy": {
                 "type": "string",
-                "description": "The account name of the user who checked out the document. Null if the document is not checked out.",
+                "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the user who checked out the document. Null if the document is not checked out.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.\nTo test whether the current authenticated user holds the checkout, use IsCheckedOutByAnotherUser; it compares stable principal identifiers internally.",
                 "nullable": true
               },
               "isCheckedOutByAnotherUser": {
                 "type": "boolean",
-                "description": "A boolean indicating if the document is checked out by a user other than the authenticated user.\nFalse if the document is not checked out or is checked out by the authenticated user.\nOnly populated on single-entry GET, not in listing results."
+                "description": "A boolean indicating if the document is checked out by a user other than the authenticated user.\nFalse if the document is not checked out or is checked out by the authenticated user.\nComputed from a stable principal identifier comparison, not from CheckedOutBy.\nOnly populated on single-entry GET, not in listing results."
               }
             }
           }
@@ -11440,6 +12603,32 @@
           }
         }
       },
+      "PageInfoCollectionResponse": {
+        "type": "object",
+        "description": "Response containing a collection of PageInfoResponse.",
+        "additionalProperties": false,
+        "properties": {
+          "@odata.nextLink": {
+            "type": "string",
+            "description": "A URL to retrieve the next page of the requested collection.",
+            "nullable": true
+          },
+          "@odata.count": {
+            "type": "integer",
+            "description": "The total count of items within a collection.",
+            "format": "int32",
+            "nullable": true
+          },
+          "value": {
+            "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/PageInfoResponse"
+            }
+          }
+        }
+      },
       "PageInfoResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -11577,7 +12766,7 @@
           },
           "owner": {
             "type": "string",
-            "description": "The account name of the lock owner (e.g., \"DOMAIN\\user\").",
+            "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the lock owner.\nSame value reported as lockedBy on Document for the same lock.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.",
             "nullable": true
           },
           "comment": {
@@ -11618,11 +12807,55 @@
             "nullable": true
           },
           "extent": {
-            "type": "string",
-            "description": "The lock extent. Valid values: \"Page\", \"Edoc\", \"Metadata\", \"All\". Defaults to \"All\".",
-            "nullable": true
+            "description": "The lock extent. Defaults to All when omitted.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LockExtent"
+              }
+            ]
           }
         }
+      },
+      "LockExtent": {
+        "type": "string",
+        "description": "The portion of a document that a persistent lock covers.",
+        "x-enum-names": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ],
+        "x-enum-varnames": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ],
+        "x-enumNames": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ]
       },
       "CheckOutDocumentRequest": {
         "type": "object",
@@ -12301,74 +13534,6 @@
             "items": {
               "$ref": "#/components/schemas/TemplateDefinition"
             }
-          }
-        }
-      },
-      "TemplateDefinition": {
-        "type": "object",
-        "description": "Represents a template definition.",
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "type": "integer",
-            "description": "The ID of the template definition.",
-            "format": "int32"
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of the template definition.",
-            "nullable": true
-          },
-          "displayName": {
-            "type": "string",
-            "description": "The localized name of the template definition.",
-            "nullable": true
-          },
-          "description": {
-            "type": "string",
-            "description": "The description of the template definition.",
-            "nullable": true
-          },
-          "color": {
-            "description": "The color assigned to the template definition.",
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/LFColor"
-              }
-            ]
-          },
-          "fieldCount": {
-            "type": "integer",
-            "description": "The number of field definitions assigned to the template definition.",
-            "format": "int32"
-          }
-        }
-      },
-      "LFColor": {
-        "type": "object",
-        "description": "Represents an RGB color value with alpha channel.",
-        "additionalProperties": false,
-        "properties": {
-          "a": {
-            "type": "integer",
-            "description": "The alpha channel component, from 0-255.",
-            "format": "byte"
-          },
-          "r": {
-            "type": "integer",
-            "description": "The red channel component, from 0-255.",
-            "format": "byte"
-          },
-          "g": {
-            "type": "integer",
-            "description": "The green channel component, from 0-255.",
-            "format": "byte"
-          },
-          "b": {
-            "type": "integer",
-            "description": "The blue channel component from 0-255.",
-            "format": "byte"
           }
         }
       },

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -1150,6 +1150,34 @@ namespace Laserfiche.Repository.Api.Client
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task<AssignedEntryCountResponse> GetFieldAssignedEntryCountAsync(GetFieldAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
+        /// <summary>
+        /// Gets the extended-properties bag for a field definition.
+        /// </summary>
+        /// <remarks>
+        /// - The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the extended properties for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<FieldPropertiesResponse> GetFieldPropertiesAsync(GetFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Partially updates the extended-properties bag for a field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
+        /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
+        /// - Returns the full property bag after the change.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the extended properties for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<FieldPropertiesResponse> UpdateFieldPropertiesAsync(UpdateFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
     }
 
     [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -2664,6 +2692,335 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
+        /// <summary>
+        /// Gets the extended-properties bag for a field definition.
+        /// </summary>
+        /// <remarks>
+        /// - The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the extended properties for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<FieldPropertiesResponse> GetFieldPropertiesAsync(GetFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var select = parameters.Select;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Properties"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Properties");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetFieldPropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<FieldPropertiesResponse> GetFieldPropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<FieldPropertiesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Partially updates the extended-properties bag for a field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
+        /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
+        /// - Returns the full property bag after the change.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the extended properties for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<FieldPropertiesResponse> UpdateFieldPropertiesAsync(UpdateFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/Properties"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Properties");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await UpdateFieldPropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<FieldPropertiesResponse> UpdateFieldPropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<FieldPropertiesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)
@@ -3010,6 +3367,52 @@ namespace Laserfiche.Repository.Api.Client
         /// Limits the properties returned in the result.
         /// </summary>
         public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.GetFieldPropertiesAsync(GetFieldPropertiesParameters, CancellationToken)">GetFieldProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetFieldPropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.UpdateFieldPropertiesAsync(UpdateFieldPropertiesParameters, CancellationToken)">UpdateFieldProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateFieldPropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.
+        /// </summary>
+        public UpdateFieldPropertiesRequest Request { get; set; }
 
     }
 
@@ -5676,7 +6079,9 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file != null)
+                        if (file == null)
+                            throw new ArgumentNullException("parameters.File");
+                        else
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -5692,7 +6097,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -5727,7 +6134,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file != null)
+                                if (file == null)
+                                    throw new ArgumentNullException("parameters.File");
+                                else
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -5743,7 +6152,9 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -8281,7 +8692,9 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file != null)
+                        if (file == null)
+                            throw new ArgumentNullException("parameters.File");
+                        else
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -8289,13 +8702,17 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_file_, "file", file.FileName ?? "file");
                             }
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -8330,7 +8747,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file != null)
+                                if (file == null)
+                                    throw new ArgumentNullException("parameters.File");
+                                else
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -8338,13 +8757,17 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_file_, "file", file.FileName ?? "file");
                                     }
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -9172,13 +9595,17 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -9213,13 +9640,17 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -9427,13 +9858,17 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -9468,13 +9903,17 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -9872,7 +10311,9 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (imageFile != null)
+                        if (imageFile == null)
+                            throw new ArgumentNullException("parameters.ImageFile");
+                        else
                         {
                                 var content_imageFile_ = new StreamContent(imageFile.Data);
                                 if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -9880,7 +10321,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                             }
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
@@ -9910,7 +10353,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (imageFile != null)
+                                if (imageFile == null)
+                                    throw new ArgumentNullException("parameters.ImageFile");
+                                else
                                 {
                                         var content_imageFile_ = new StreamContent(imageFile.Data);
                                         if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -9918,7 +10363,9 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                                     }
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
@@ -18885,6 +19332,15 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("listValues", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<string> ListValues { get; set; }
 
+        /// <summary>
+        /// Initial extended properties (opaque WebDAV-keyed bag) to persist atomically with the field.<br/>
+        /// Use the dedicated /FieldDefinitions/{id}/Properties endpoints to manage after creation.<br/>
+        /// For list fields, this is where the admin UI stores sort order, add-blank, add-Other,<br/>
+        /// display-as-dropdown, and similar UI-display options.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("properties", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IDictionary<string, string> Properties { get; set; }
+
     }
 
     /// <summary>
@@ -19113,6 +19569,44 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("count", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Count { get; set; }
+
+    }
+
+    /// <summary>
+    /// Response body for the extended-properties bag on a field definition. The bag is opaque:<br/>
+    /// keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field<br/>
+    /// sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class FieldPropertiesResponse
+    {
+        /// <summary>
+        /// The full set of extended properties currently set on the field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("properties", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IDictionary<string, string> Properties { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for partially updating the extended-properties bag on a field definition.<br/>
+    /// Entries in Set are written (creating or overwriting). Entries in Remove<br/>
+    /// are deleted. Properties not mentioned in either are left unchanged.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateFieldPropertiesRequest
+    {
+        /// <summary>
+        /// Properties to set. Keys absent here are not modified.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("set", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IDictionary<string, string> Set { get; set; }
+
+        /// <summary>
+        /// Property keys to remove. Keys not currently set are ignored.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("remove", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<string> Remove { get; set; }
 
     }
 

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -1040,6 +1040,34 @@ namespace Laserfiche.Repository.Api.Client
         Task<FieldDefinition> GetFieldDefinitionAsync(GetFieldDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Updates properties of an existing field definition (partial update).
+        /// </summary>
+        /// <remarks>
+        /// - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.<br/>
+        /// - FieldType cannot be changed via this endpoint — use the dedicated ChangeFieldType endpoint.<br/>
+        /// - ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<FieldDefinition> UpdateFieldDefinitionAsync(UpdateFieldDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Deletes a field definition from the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Deletes the specified field definition. Behavior when the field is referenced by templates or assigned to entries mirrors the underlying repository server response — if rejected by the server, the response surfaces the server error.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully deleted the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task DeleteFieldDefinitionAsync(DeleteFieldDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Returns the paged listing of the field definitions available in a repository.
         /// </summary>
         /// <remarks>
@@ -1053,6 +1081,74 @@ namespace Laserfiche.Repository.Api.Client
         /// <returns>Successfully returned field definitions.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task<FieldDefinitionCollectionResponse> ListFieldDefinitionsAsync(ListFieldDefinitionsParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Creates a new field definition in the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Creates a new metadata field definition with the supplied core attributes, flags, and (optionally) initial list values for list-backed fields.<br/>
+        /// - Names must be unique within the repository; duplicate-name failures return 400.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully created the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<FieldDefinition> CreateFieldDefinitionAsync(CreateFieldDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns the list values configured on a list-backed field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Returns the field's configured list-item values in repository-configured order.<br/>
+        /// - Applies only to list-backed fields; non-list fields return an empty array.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the list values for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<ListValuesResponse> GetFieldListValuesAsync(GetFieldListValuesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Replaces the list values for a list-backed field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Replaces the field's full list-item set wholesale. No partial add/remove endpoints are exposed.<br/>
+        /// - Duplicates and empty-string values are rejected with 400.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully replaced the list values for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<ListValuesResponse> ReplaceFieldListValuesAsync(ReplaceFieldListValuesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns the templates that contain the specified field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Lists template definitions that include the specified field. Useful before performing destructive operations on the field.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the templates that contain the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<IList<TemplateDefinition>> GetFieldContainingTemplatesAsync(GetFieldContainingTemplatesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns the count of entries that have a value assigned for the specified field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Useful for impact analysis before performing destructive operations such as type changes or deletion.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the count of entries assigned to the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<AssignedEntryCountResponse> GetFieldAssignedEntryCountAsync(GetFieldAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
     }
 
@@ -1176,6 +1272,322 @@ namespace Laserfiche.Repository.Api.Client
                         throw ApiExceptionExtensions.Create(status_, headers_, null);
                     }
                     return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Updates properties of an existing field definition (partial update).
+        /// </summary>
+        /// <remarks>
+        /// - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.<br/>
+        /// - FieldType cannot be changed via this endpoint — use the dedicated ChangeFieldType endpoint.<br/>
+        /// - ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<FieldDefinition> UpdateFieldDefinitionAsync(UpdateFieldDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await UpdateFieldDefinitionSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<FieldDefinition> UpdateFieldDefinitionSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<FieldDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Deletes a field definition from the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Deletes the specified field definition. Behavior when the field is referenced by templates or assigned to entries mirrors the underlying repository server response — if rejected by the server, the response surfaces the server error.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully deleted the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task DeleteFieldDefinitionAsync(DeleteFieldDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("DELETE");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await DeleteFieldDefinitionSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task DeleteFieldDefinitionSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
                 }
                 else
                 if (status_ == 400)
@@ -1438,6 +1850,820 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
+        /// <summary>
+        /// Creates a new field definition in the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Creates a new metadata field definition with the supplied core attributes, flags, and (optionally) initial list values for list-backed fields.<br/>
+        /// - Names must be unique within the repository; duplicate-name failures return 400.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully created the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<FieldDefinition> CreateFieldDefinitionAsync(CreateFieldDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await CreateFieldDefinitionSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<FieldDefinition> CreateFieldDefinitionSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<FieldDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Returns the list values configured on a list-backed field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Returns the field's configured list-item values in repository-configured order.<br/>
+        /// - Applies only to list-backed fields; non-list fields return an empty array.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the list values for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<ListValuesResponse> GetFieldListValuesAsync(GetFieldListValuesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var select = parameters.Select;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/ListValues");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetFieldListValuesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<ListValuesResponse> GetFieldListValuesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ListValuesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Replaces the list values for a list-backed field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Replaces the field's full list-item set wholesale. No partial add/remove endpoints are exposed.<br/>
+        /// - Duplicates and empty-string values are rejected with 400.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully replaced the list values for the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<ListValuesResponse> ReplaceFieldListValuesAsync(ReplaceFieldListValuesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/ListValues");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PUT");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await ReplaceFieldListValuesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<ListValuesResponse> ReplaceFieldListValuesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ListValuesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Returns the templates that contain the specified field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Lists template definitions that include the specified field. Useful before performing destructive operations on the field.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the templates that contain the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<IList<TemplateDefinition>> GetFieldContainingTemplatesAsync(GetFieldContainingTemplatesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var select = parameters.Select;
+            var orderby = parameters.Orderby;
+            var count = parameters.Count;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ContainingTemplates"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/ContainingTemplates");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (orderby != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$orderby")).Append('=').Append(Uri.EscapeDataString(ConvertToString(orderby, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (count != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$count")).Append('=').Append(Uri.EscapeDataString(ConvertToString(count, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetFieldContainingTemplatesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<IList<TemplateDefinition>> GetFieldContainingTemplatesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<IList<TemplateDefinition>>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Returns the count of entries that have a value assigned for the specified field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Useful for impact analysis before performing destructive operations such as type changes or deletion.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the count of entries assigned to the field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<AssignedEntryCountResponse> GetFieldAssignedEntryCountAsync(GetFieldAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var select = parameters.Select;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/AssignedEntryCount"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/AssignedEntryCount");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetFieldAssignedEntryCountSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<AssignedEntryCountResponse> GetFieldAssignedEntryCountSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<AssignedEntryCountResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)
@@ -1579,6 +2805,47 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.UpdateFieldDefinitionAsync(UpdateFieldDefinitionParameters, CancellationToken)">UpdateFieldDefinition</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateFieldDefinitionParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition to update.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// The properties to change. Only non-null properties are applied; null leaves the property unchanged. Empty string clears a string property.
+        /// </summary>
+        public UpdateFieldDefinitionRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.DeleteFieldDefinitionAsync(DeleteFieldDefinitionParameters, CancellationToken)">DeleteFieldDefinition</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class DeleteFieldDefinitionParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition to delete.
+        /// </summary>
+        public int FieldId { get; set; }
+
+    }
+
+    /// <summary>
     /// Represents the request parameters for <see cref="IFieldDefinitionsClient.ListFieldDefinitionsAsync(ListFieldDefinitionsParameters, CancellationToken)">ListFieldDefinitions</see>.
     /// </summary>
     [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -1623,6 +2890,126 @@ namespace Laserfiche.Repository.Api.Client
         /// Indicates whether the total count of items within a collection are returned in the result.
         /// </summary>
         public bool? Count { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.CreateFieldDefinitionAsync(CreateFieldDefinitionParameters, CancellationToken)">CreateFieldDefinition</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CreateFieldDefinitionParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The field definition to create. Name and FieldType are required.
+        /// </summary>
+        public CreateFieldDefinitionRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.GetFieldListValuesAsync(GetFieldListValuesParameters, CancellationToken)">GetFieldListValues</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetFieldListValuesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.ReplaceFieldListValuesAsync(ReplaceFieldListValuesParameters, CancellationToken)">ReplaceFieldListValues</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ReplaceFieldListValuesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// The new list of values. Order is preserved. Empty array clears the list.
+        /// </summary>
+        public ReplaceListValuesRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.GetFieldContainingTemplatesAsync(GetFieldContainingTemplatesParameters, CancellationToken)">GetFieldContainingTemplates</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetFieldContainingTemplatesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
+
+        /// <summary>
+        /// Specifies the order in which items are returned. The maximum number of expressions is 5.
+        /// </summary>
+        public string Orderby { get; set; } = null;
+
+        /// <summary>
+        /// Indicates whether the total count of items within a collection are returned in the result.
+        /// </summary>
+        public bool? Count { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.GetFieldAssignedEntryCountAsync(GetFieldAssignedEntryCountParameters, CancellationToken)">GetFieldAssignedEntryCount</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetFieldAssignedEntryCountParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
 
     }
 
@@ -2554,7 +3941,7 @@ namespace Laserfiche.Repository.Api.Client
         ///   - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.<br/>
         /// - If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.<br/>
         /// - Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.<br/>
-        /// - `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.<br/>
+        /// - `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.<br/>
         /// - Required OAuth scope: repository.Write
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -7131,7 +8518,7 @@ namespace Laserfiche.Repository.Api.Client
         ///   - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.<br/>
         /// - If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.<br/>
         /// - Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.<br/>
-        /// - `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.<br/>
+        /// - `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.<br/>
         /// - Required OAuth scope: repository.Write
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -10982,6 +12369,26 @@ namespace Laserfiche.Repository.Api.Client
                     throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 409)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 423)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -11330,6 +12737,16 @@ namespace Laserfiche.Repository.Api.Client
                 }
                 else
                 if (status_ == 409)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 423)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                     if (objectResponse_.Object == null)
@@ -11857,7 +13274,7 @@ namespace Laserfiche.Repository.Api.Client
         public ImportEntryRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -12295,7 +13712,7 @@ namespace Laserfiche.Repository.Api.Client
         public UpdateDocumentRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -12394,7 +13811,7 @@ namespace Laserfiche.Repository.Api.Client
         public PagesContentRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -12424,7 +13841,7 @@ namespace Laserfiche.Repository.Api.Client
         public PagesContentRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -17209,6 +18626,37 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("formatPattern", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string FormatPattern { get; set; }
 
+        /// <summary>
+        /// A boolean indicating whether the field is indexed for searching.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isIndexed", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsIndexed { get; set; }
+
+        /// <summary>
+        /// A boolean indicating whether the field is indexed for reporting.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isIndexedForReporting", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsIndexedForReporting { get; set; }
+
+        /// <summary>
+        /// A boolean indicating whether the user should be warned when leaving the field blank.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("warnIfBlank", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool WarnIfBlank { get; set; }
+
+        /// <summary>
+        /// A boolean indicating whether the field's list values should be hidden in the UI.<br/>
+        /// Applies only to list-backed fields.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("hideListValues", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool HideListValues { get; set; }
+
+        /// <summary>
+        /// A boolean indicating whether values for this field can be automatically extracted by AI/OCR services.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("autoExtract", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool AutoExtract { get; set; }
+
     }
 
     /// <summary>
@@ -17315,6 +18763,356 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<FieldDefinition> Value { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for creating a new field definition. Name and FieldType are required;<br/>
+    /// all other properties are optional and fall back to repository defaults when omitted.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CreateFieldDefinitionRequest
+    {
+        /// <summary>
+        /// The name of the field. Required. Must be unique within the repository.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The type of the field. Required. Cannot be changed via UpdateFieldDefinition;<br/>
+        /// use the ChangeFieldType endpoint to convert between types.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldType", Required = Newtonsoft.Json.Required.Always)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FieldType FieldType { get; set; }
+
+        /// <summary>
+        /// The description of the field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The maximum length of the field for variable-length data types.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("length", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Length { get; set; }
+
+        /// <summary>
+        /// The default value applied to entries assigned to a template containing this field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("defaultValue", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultValue { get; set; }
+
+        /// <summary>
+        /// The display format for the field. Defaults to None when omitted.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("format", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FieldFormat? Format { get; set; }
+
+        /// <summary>
+        /// The custom format pattern. Only meaningful when Format is set to a value that supports custom patterns.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("formatPattern", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string FormatPattern { get; set; }
+
+        /// <summary>
+        /// The currency for numeric fields when Format is Currency.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("currency", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// A validation constraint expression for values stored in this field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("constraint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Constraint { get; set; }
+
+        /// <summary>
+        /// The error message returned when the constraint is violated.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("constraintError", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ConstraintError { get; set; }
+
+        /// <summary>
+        /// Whether the field supports multiple values.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isMultiValue", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsMultiValue { get; set; }
+
+        /// <summary>
+        /// Whether the field is required on entries assigned to a template containing it.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// Whether the field is indexed for searching.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isIndexed", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsIndexed { get; set; }
+
+        /// <summary>
+        /// Whether the field is indexed for reporting.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isIndexedForReporting", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsIndexedForReporting { get; set; }
+
+        /// <summary>
+        /// Whether the user should be warned when leaving the field blank.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("warnIfBlank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? WarnIfBlank { get; set; }
+
+        /// <summary>
+        /// Whether list values should be hidden in the UI. Applies only to list-backed fields.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("hideListValues", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? HideListValues { get; set; }
+
+        /// <summary>
+        /// Whether values for this field can be automatically extracted by AI/OCR services.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("autoExtract", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? AutoExtract { get; set; }
+
+        /// <summary>
+        /// Initial list values to populate. Applies only when FieldType is List.<br/>
+        /// Order is preserved. Use the dedicated ListValues endpoints to manage list values after creation.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("listValues", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<string> ListValues { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for partial-update of an existing field definition. Every property is optional.<br/>
+    /// null = leave the property unchanged.<br/>
+    /// Empty string ("") on a string property = clear the value.<br/>
+    /// FieldType cannot be changed via this endpoint — use the ChangeFieldType endpoint.<br/>
+    /// ListValues cannot be changed via this endpoint — use the dedicated ListValues endpoints.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateFieldDefinitionRequest
+    {
+        /// <summary>
+        /// The new name of the field. Must be unique within the repository.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The description of the field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The maximum length of the field for variable-length data types.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("length", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Length { get; set; }
+
+        /// <summary>
+        /// The default value applied to entries assigned to a template containing this field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("defaultValue", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultValue { get; set; }
+
+        /// <summary>
+        /// The display format for the field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("format", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FieldFormat? Format { get; set; }
+
+        /// <summary>
+        /// The custom format pattern.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("formatPattern", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string FormatPattern { get; set; }
+
+        /// <summary>
+        /// The currency for numeric fields when Format is Currency.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("currency", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// A validation constraint expression for values stored in this field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("constraint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Constraint { get; set; }
+
+        /// <summary>
+        /// The error message returned when the constraint is violated.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("constraintError", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ConstraintError { get; set; }
+
+        /// <summary>
+        /// Whether the field supports multiple values.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isMultiValue", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsMultiValue { get; set; }
+
+        /// <summary>
+        /// Whether the field is required on entries assigned to a template containing it.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// Whether the field is indexed for searching.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isIndexed", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsIndexed { get; set; }
+
+        /// <summary>
+        /// Whether the field is indexed for reporting.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isIndexedForReporting", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsIndexedForReporting { get; set; }
+
+        /// <summary>
+        /// Whether the user should be warned when leaving the field blank.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("warnIfBlank", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? WarnIfBlank { get; set; }
+
+        /// <summary>
+        /// Whether list values should be hidden in the UI. Applies only to list-backed fields.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("hideListValues", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? HideListValues { get; set; }
+
+        /// <summary>
+        /// Whether values for this field can be automatically extracted by AI/OCR services.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("autoExtract", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? AutoExtract { get; set; }
+
+    }
+
+    /// <summary>
+    /// Response containing the list values of a field definition, in the order configured on the server.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ListValuesResponse
+    {
+        /// <summary>
+        /// The ordered list of list-item values.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("values", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<string> Values { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for replacing the list values of a list-backed field definition.<br/>
+    /// The provided values replace the field's full list-item set wholesale, preserving the supplied order.<br/>
+    /// An empty array clears the list.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ReplaceListValuesRequest
+    {
+        /// <summary>
+        /// The ordered list of list-item values to apply. Duplicates and empty strings are rejected with 400.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("values", Required = Newtonsoft.Json.Required.Always)]
+        public IList<string> Values { get; set; } = new List<string>();
+
+    }
+
+    /// <summary>
+    /// Represents a template definition.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class TemplateDefinition
+    {
+        /// <summary>
+        /// The ID of the template definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the template definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The localized name of the template definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("displayName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// The description of the template definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The color assigned to the template definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public LFColor Color { get; set; }
+
+        /// <summary>
+        /// The number of field definitions assigned to the template definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int FieldCount { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents an RGB color value with alpha channel.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class LFColor
+    {
+        /// <summary>
+        /// The alpha channel component, from 0-255.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("a", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public byte A { get; set; }
+
+        /// <summary>
+        /// The red channel component, from 0-255.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("r", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public byte R { get; set; }
+
+        /// <summary>
+        /// The green channel component, from 0-255.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("g", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public byte G { get; set; }
+
+        /// <summary>
+        /// The blue channel component from 0-255.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("b", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public byte B { get; set; }
+
+    }
+
+    /// <summary>
+    /// The number of entries that have a value assigned for a given field definition.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AssignedEntryCountResponse
+    {
+        /// <summary>
+        /// The count of entries currently using this field.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("count", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int Count { get; set; }
 
     }
 
@@ -18182,7 +19980,9 @@ namespace Laserfiche.Repository.Api.Client
         public bool IsLocked { get; set; }
 
         /// <summary>
-        /// The account name of the persistent lock holder. Null if the document is not locked.
+        /// Display name (account name, e.g. "DOMAIN\user") of the persistent lock holder. Null if the document is not locked.<br/>
+        /// Account renames change this value over time — do not use for stable identity comparisons.<br/>
+        /// To test whether the current authenticated user holds the lock, use IsLockedByAnotherUser; it compares stable principal identifiers internally.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("lockedBy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string LockedBy { get; set; }
@@ -18190,6 +19990,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// A boolean indicating if the document is locked by a user other than the authenticated user.<br/>
         /// False if the document is not locked or is locked by the authenticated user.<br/>
+        /// Computed from a stable principal identifier comparison, not from LockedBy.<br/>
         /// Only populated on single-entry GET, not in listing results.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("isLockedByAnotherUser", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -18202,7 +20003,9 @@ namespace Laserfiche.Repository.Api.Client
         public int CurrentVersion { get; set; }
 
         /// <summary>
-        /// The account name of the user who checked out the document. Null if the document is not checked out.
+        /// Display name (account name, e.g. "DOMAIN\user") of the user who checked out the document. Null if the document is not checked out.<br/>
+        /// Account renames change this value over time — do not use for stable identity comparisons.<br/>
+        /// To test whether the current authenticated user holds the checkout, use IsCheckedOutByAnotherUser; it compares stable principal identifiers internally.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("checkedOutBy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string CheckedOutBy { get; set; }
@@ -18210,6 +20013,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// A boolean indicating if the document is checked out by a user other than the authenticated user.<br/>
         /// False if the document is not checked out or is checked out by the authenticated user.<br/>
+        /// Computed from a stable principal identifier comparison, not from CheckedOutBy.<br/>
         /// Only populated on single-entry GET, not in listing results.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("isCheckedOutByAnotherUser", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -18638,32 +20442,6 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
-    /// Response containing a collection of PageInfoResponse.
-    /// </summary>
-    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class PageInfoCollectionResponse
-    {
-        /// <summary>
-        /// A URL to retrieve the next page of the requested collection.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("@odata.nextLink", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string OdataNextLink { get; set; }
-
-        /// <summary>
-        /// The total count of items within a collection.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? OdataCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public IList<PageInfoResponse> Value { get; set; }
-
-    }
-
-    /// <summary>
     /// Represents a link between a source entry and a target entry.
     /// </summary>
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -19004,6 +20782,32 @@ namespace Laserfiche.Repository.Api.Client
 
     }
 
+    /// <summary>
+    /// Response containing a collection of PageInfoResponse.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class PageInfoCollectionResponse
+    {
+        /// <summary>
+        /// A URL to retrieve the next page of the requested collection.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("@odata.nextLink", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string OdataNextLink { get; set; }
+
+        /// <summary>
+        /// The total count of items within a collection.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? OdataCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OData response content in the "value".
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<PageInfoResponse> Value { get; set; }
+
+    }
+
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class PageInfoResponse
     {
@@ -19118,7 +20922,9 @@ namespace Laserfiche.Repository.Api.Client
         public string LockToken { get; set; }
 
         /// <summary>
-        /// The account name of the lock owner (e.g., "DOMAIN\user").
+        /// Display name (account name, e.g. "DOMAIN\user") of the lock owner.<br/>
+        /// Same value reported as lockedBy on Document for the same lock.<br/>
+        /// Account renames change this value over time — do not use for stable identity comparisons.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Owner { get; set; }
@@ -19168,10 +20974,32 @@ namespace Laserfiche.Repository.Api.Client
         public string Comment { get; set; }
 
         /// <summary>
-        /// The lock extent. Valid values: "Page", "Edoc", "Metadata", "All". Defaults to "All".
+        /// The lock extent. Defaults to All when omitted.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("extent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Extent { get; set; }
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public LockExtent? Extent { get; set; }
+
+    }
+
+    /// <summary>
+    /// The portion of a document that a persistent lock covers.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum LockExtent
+    {
+
+        [EnumMember(Value = @"Page")]
+        Page = 0,
+
+        [EnumMember(Value = @"Edoc")]
+        Edoc = 1,
+
+        [EnumMember(Value = @"Metadata")]
+        Metadata = 2,
+
+        [EnumMember(Value = @"All")]
+        All = 3,
 
     }
 
@@ -19761,82 +21589,6 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<TemplateDefinition> Value { get; set; }
-
-    }
-
-    /// <summary>
-    /// Represents a template definition.
-    /// </summary>
-    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class TemplateDefinition
-    {
-        /// <summary>
-        /// The ID of the template definition.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("id", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int Id { get; set; }
-
-        /// <summary>
-        /// The name of the template definition.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Name { get; set; }
-
-        /// <summary>
-        /// The localized name of the template definition.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("displayName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string DisplayName { get; set; }
-
-        /// <summary>
-        /// The description of the template definition.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Description { get; set; }
-
-        /// <summary>
-        /// The color assigned to the template definition.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public LFColor Color { get; set; }
-
-        /// <summary>
-        /// The number of field definitions assigned to the template definition.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("fieldCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int FieldCount { get; set; }
-
-    }
-
-    /// <summary>
-    /// Represents an RGB color value with alpha channel.
-    /// </summary>
-    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class LFColor
-    {
-        /// <summary>
-        /// The alpha channel component, from 0-255.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("a", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public byte A { get; set; }
-
-        /// <summary>
-        /// The red channel component, from 0-255.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("r", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public byte R { get; set; }
-
-        /// <summary>
-        /// The green channel component, from 0-255.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("g", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public byte G { get; set; }
-
-        /// <summary>
-        /// The blue channel component from 0-255.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("b", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public byte B { get; set; }
 
     }
 

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -6079,9 +6079,7 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file == null)
-                            throw new ArgumentNullException("parameters.File");
-                        else
+                        if (file != null)
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -6097,9 +6095,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -6134,9 +6130,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file == null)
-                                    throw new ArgumentNullException("parameters.File");
-                                else
+                                if (file != null)
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -6152,9 +6146,7 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -8692,9 +8684,7 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file == null)
-                            throw new ArgumentNullException("parameters.File");
-                        else
+                        if (file != null)
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -8702,17 +8692,13 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_file_, "file", file.FileName ?? "file");
                             }
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -8747,9 +8733,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file == null)
-                                    throw new ArgumentNullException("parameters.File");
-                                else
+                                if (file != null)
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -8757,17 +8741,13 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_file_, "file", file.FileName ?? "file");
                                     }
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -9595,17 +9575,13 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -9640,17 +9616,13 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -9858,17 +9830,13 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -9903,17 +9871,13 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -10311,9 +10275,7 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (imageFile == null)
-                            throw new ArgumentNullException("parameters.ImageFile");
-                        else
+                        if (imageFile != null)
                         {
                                 var content_imageFile_ = new StreamContent(imageFile.Data);
                                 if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -10321,9 +10283,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                             }
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
@@ -10353,9 +10313,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (imageFile == null)
-                                    throw new ArgumentNullException("parameters.ImageFile");
-                                else
+                                if (imageFile != null)
                                 {
                                         var content_imageFile_ = new StreamContent(imageFile.Data);
                                         if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -10363,9 +10321,7 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                                     }
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");

--- a/tests/integration/Entries/LockDocumentTest.cs
+++ b/tests/integration/Entries/LockDocumentTest.cs
@@ -38,7 +38,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 RepositoryId = RepositoryId,
                 EntryId = createdEntryId,
-                Request = new LockDocumentRequest() { Comment = "client test lock", Extent = "All" }
+                Request = new LockDocumentRequest() { Comment = "client test lock", Extent = LockExtent.All }
             }).ConfigureAwait(false);
 
             Assert.IsNotNull(lockResult);

--- a/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
+++ b/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
+using Laserfiche.Api.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -286,6 +287,247 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
 
                 Assert.IsNotNull(count);
                 Assert.AreEqual(0, count.Count);
+            }
+            finally
+            {
+                if (createdId > 0)
+                {
+                    await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+
+        // ---------------- Coverage tests added during pre-PR review ----------------
+
+        // Test #1: end-to-end round-trip for every FieldType, ensuring the dotnet client
+        // serializes each type without crashing and the server persists+returns it correctly.
+        // List values are only meaningful for FieldType.List; other type-specific flags
+        // (Format/Currency for Number/Date/Time) are exercised separately by AllFlags tests
+        // — this one is purely "does the type itself round-trip".
+        [TestMethod]
+        public async Task AllFieldTypes_CreateDescribeUpdate_RoundTrip()
+        {
+            var types = new[]
+            {
+                FieldType.String,
+                FieldType.List,
+                FieldType.Number,
+                FieldType.Date,
+                FieldType.DateTime,
+                FieldType.Time,
+                FieldType.ShortInteger,
+                FieldType.LongInteger,
+            };
+            // FieldType.Blob is supported by RA but historically not exercised via the admin API;
+            // skip rather than risk an asymmetric failure that's out of scope for 6.3.A.
+
+            foreach (var fieldType in types)
+            {
+                string fieldName = UniqueName($"client_test_type_{fieldType}");
+                int createdId = 0;
+                try
+                {
+                    var createReq = new CreateFieldDefinitionRequest
+                    {
+                        Name = fieldName,
+                        FieldType = fieldType,
+                        Description = $"Round-trip test for {fieldType}",
+                    };
+                    if (fieldType == FieldType.String || fieldType == FieldType.List)
+                    {
+                        createReq.Length = 25;
+                    }
+                    if (fieldType == FieldType.List)
+                    {
+                        createReq.ListValues = new List<string> { "Alpha", "Beta" };
+                    }
+
+                    var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        Request = createReq,
+                    }).ConfigureAwait(false);
+                    Assert.IsTrue(created.Id > 0, $"{fieldType}: id not assigned");
+                    Assert.AreEqual(fieldType, created.FieldType, $"{fieldType}: round-tripped type mismatch");
+                    createdId = created.Id;
+
+                    // Independent GET (defense against same-request masking — Trap 4 discipline).
+                    var fetched = await client.FieldDefinitionsClient.GetFieldDefinitionAsync(new GetFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                    Assert.AreEqual(fieldType, fetched.FieldType, $"{fieldType}: GET fieldType mismatch");
+                    Assert.AreEqual($"Round-trip test for {fieldType}", fetched.Description);
+
+                    // PATCH description; verify it sticks regardless of type.
+                    var updated = await client.FieldDefinitionsClient.UpdateFieldDefinitionAsync(new UpdateFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                        Request = new UpdateFieldDefinitionRequest
+                        {
+                            Description = "Updated for " + fieldType,
+                        },
+                    }).ConfigureAwait(false);
+                    Assert.AreEqual("Updated for " + fieldType, updated.Description, $"{fieldType}: PATCH didn't stick");
+                }
+                finally
+                {
+                    if (createdId > 0)
+                    {
+                        await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                        {
+                            RepositoryId = RepositoryId,
+                            FieldId = createdId,
+                        }).ConfigureAwait(false);
+                    }
+                }
+            }
+        }
+
+        // Test #2: GET /Properties on a fresh field with no caller-set properties.
+        // Codex round-3 finding #4 raised the possibility that LFS returns internal entries
+        // alongside (or instead of) caller-set keys. This test surfaces what comes back so
+        // PR reviewers and future maintainers have concrete evidence of the contract.
+        [TestMethod]
+        public async Task GetFieldProperties_OnFreshField_DocumentsLfsInternalEntries()
+        {
+            string fieldName = UniqueName("client_test_props_probe");
+            int createdId = 0;
+            try
+            {
+                var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = fieldName,
+                        FieldType = FieldType.String,
+                        Length = 10,
+                        // intentionally no Properties supplied
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var bag = await client.FieldDefinitionsClient.GetFieldPropertiesAsync(new GetFieldPropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(bag);
+                Assert.IsNotNull(bag.Properties);
+                // The bag may be empty (LFS doesn't auto-populate) or contain a stable set of
+                // RA-managed keys. We don't constrain — we record. If a future server change
+                // begins surfacing PII or unexpected internals, that change should be flagged
+                // here. Print to test output for triage.
+                Console.WriteLine($"GetFieldProperties on fresh field returned {bag.Properties.Count} entries:");
+                foreach (var kv in bag.Properties)
+                {
+                    Console.WriteLine($"  [{kv.Key}] = [{kv.Value}]");
+                }
+                // Assertion: any caller-visible keys must be reasonable WebDAV-style identifiers
+                // (no control chars, not absurdly long) — defends against the round-3 "what if
+                // LFS leaks something weird" concern.
+                foreach (var kv in bag.Properties)
+                {
+                    Assert.IsFalse(string.IsNullOrEmpty(kv.Key), "LFS returned an empty property key");
+                    Assert.IsTrue(kv.Key.Length <= 256, $"LFS returned an oversized property key: '{kv.Key}'");
+                }
+            }
+            finally
+            {
+                if (createdId > 0)
+                {
+                    await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+
+        // Test #3: server-side 400 validations surface through the dotnet client as
+        // ApiException with parseable ProblemDetails. Covers a representative sample of
+        // the round-1/2/3 validation tightenings (length<1, listValues-on-non-list,
+        // properties empty key, duplicate set+remove).
+        [TestMethod]
+        public async Task Validation_RoundTripsAs400ProblemDetails()
+        {
+            // length=0 on Create — server rejects with 400 + instanceDetail "length"
+            var ex1 = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = UniqueName("client_test_invalid"),
+                        FieldType = FieldType.String,
+                        Length = 0,
+                    },
+                }).ConfigureAwait(false)).ConfigureAwait(false);
+            Assert.AreEqual(400, ex1.StatusCode);
+            Assert.IsNotNull(ex1.ProblemDetails.Title);
+
+            // listValues supplied for a non-List type — server rejects
+            var ex2 = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = UniqueName("client_test_invalid"),
+                        FieldType = FieldType.String,
+                        Length = 10,
+                        ListValues = new List<string> { "A", "B" },
+                    },
+                }).ConfigureAwait(false)).ConfigureAwait(false);
+            Assert.AreEqual(400, ex2.StatusCode);
+
+            // Need a real field to exercise the PATCH /Properties validations.
+            string fieldName = UniqueName("client_test_props_validation");
+            int createdId = 0;
+            try
+            {
+                var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest { Name = fieldName, FieldType = FieldType.String, Length = 10 }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                // PATCH /Properties with an empty key — server rejects
+                var ex3 = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                    await client.FieldDefinitionsClient.UpdateFieldPropertiesAsync(new UpdateFieldPropertiesParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                        Request = new UpdateFieldPropertiesRequest
+                        {
+                            Set = new Dictionary<string, string> { { "", "v" } },
+                        },
+                    }).ConfigureAwait(false)).ConfigureAwait(false);
+                Assert.AreEqual(400, ex3.StatusCode);
+
+                // PATCH /Properties with a key in both set and remove — server rejects
+                var ex4 = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                    await client.FieldDefinitionsClient.UpdateFieldPropertiesAsync(new UpdateFieldPropertiesParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                        Request = new UpdateFieldPropertiesRequest
+                        {
+                            Set = new Dictionary<string, string> { { "shared", "v" } },
+                            Remove = new List<string> { "shared" },
+                        },
+                    }).ConfigureAwait(false)).ConfigureAwait(false);
+                Assert.AreEqual(400, ex4.StatusCode);
             }
             finally
             {

--- a/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
+++ b/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
@@ -191,6 +191,80 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
         }
 
         [TestMethod]
+        public async Task ExtendedProperties_CreateGetUpdate_RoundTrip()
+        {
+            string fieldName = UniqueName("client_test_props_field");
+            int createdId = 0;
+            try
+            {
+                // Create with an initial property set — atomic with the create call.
+                var initialProps = new Dictionary<string, string>
+                {
+                    { "lf-cli-test-key1", "alpha" },
+                    { "lf-cli-test-key2", "beta" },
+                };
+                var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = fieldName,
+                        FieldType = FieldType.String,
+                        Length = 25,
+                        Properties = initialProps,
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                // GET — bag should include the two keys we set on Create (server may also include
+                // RA-internal properties; we only assert ours are present, not exclusivity).
+                var bag = await client.FieldDefinitionsClient.GetFieldPropertiesAsync(new GetFieldPropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsTrue(bag.Properties.ContainsKey("lf-cli-test-key1"));
+                Assert.AreEqual("alpha", bag.Properties["lf-cli-test-key1"]);
+                Assert.AreEqual("beta", bag.Properties["lf-cli-test-key2"]);
+
+                // PATCH — set one new key, remove one of the existing keys.
+                var afterUpdate = await client.FieldDefinitionsClient.UpdateFieldPropertiesAsync(new UpdateFieldPropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                    Request = new UpdateFieldPropertiesRequest
+                    {
+                        Set = new Dictionary<string, string> { { "lf-cli-test-key3", "gamma" } },
+                        Remove = new List<string> { "lf-cli-test-key1" },
+                    },
+                }).ConfigureAwait(false);
+                Assert.IsFalse(afterUpdate.Properties.ContainsKey("lf-cli-test-key1"), "key1 should be removed");
+                Assert.AreEqual("beta", afterUpdate.Properties["lf-cli-test-key2"], "key2 should be unchanged");
+                Assert.AreEqual("gamma", afterUpdate.Properties["lf-cli-test-key3"], "key3 should be added");
+
+                // Independent GET — verify the PATCH persisted (defense against same-request masking).
+                var afterUpdateReread = await client.FieldDefinitionsClient.GetFieldPropertiesAsync(new GetFieldPropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsFalse(afterUpdateReread.Properties.ContainsKey("lf-cli-test-key1"));
+                Assert.AreEqual("gamma", afterUpdateReread.Properties["lf-cli-test-key3"]);
+            }
+            finally
+            {
+                if (createdId > 0)
+                {
+                    await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+
+        [TestMethod]
         public async Task GetAssignedEntryCount_BrandNewField_ReturnsZero()
         {
             string fieldName = UniqueName("client_test_unassigned_field");

--- a/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
+++ b/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
@@ -1,0 +1,214 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
+{
+    /// <summary>
+    /// Integration tests for the field-definition admin endpoints introduced by PRD 6.3.A:
+    /// Create / Update / Delete + GetListValues / ReplaceListValues + GetContainingTemplates + GetAssignedEntryCount.
+    /// </summary>
+    [TestClass]
+    public class FieldDefinitionAdminTest : BaseTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+        }
+
+        private static string UniqueName(string prefix) =>
+            $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid().ToString("N").Substring(0, 6)}";
+
+        [TestMethod]
+        public async Task CreateUpdateDelete_StringField_Lifecycle()
+        {
+            string fieldName = UniqueName("client_test_field");
+            int createdId = 0;
+            try
+            {
+                // Create
+                var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = fieldName,
+                        FieldType = FieldType.String,
+                        Length = 50,
+                        Description = "Created from .NET client integration test",
+                        IsIndexed = true,
+                        WarnIfBlank = true,
+                    }
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(created);
+                Assert.IsTrue(created.Id > 0);
+                Assert.AreEqual(fieldName, created.Name);
+                Assert.AreEqual(FieldType.String, created.FieldType);
+                Assert.IsTrue(created.IsIndexed);
+                Assert.IsTrue(created.WarnIfBlank);
+                createdId = created.Id;
+
+                // Update — patch description and IsRequired only
+                var updated = await client.FieldDefinitionsClient.UpdateFieldDefinitionAsync(new UpdateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                    Request = new UpdateFieldDefinitionRequest
+                    {
+                        Description = "Updated description",
+                        IsRequired = true,
+                    }
+                }).ConfigureAwait(false);
+                Assert.AreEqual("Updated description", updated.Description);
+                Assert.IsTrue(updated.IsRequired);
+                Assert.AreEqual(fieldName, updated.Name); // Name preserved (not in PATCH)
+                Assert.IsTrue(updated.IsIndexed);          // Flag preserved (not in PATCH)
+            }
+            finally
+            {
+                if (createdId > 0)
+                {
+                    await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task ListField_ReplaceListValues_RoundTrip()
+        {
+            string fieldName = UniqueName("client_test_list_field");
+            int createdId = 0;
+            try
+            {
+                var initial = new List<string> { "Alpha", "Beta", "Gamma" };
+                var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = fieldName,
+                        FieldType = FieldType.List,
+                        ListValues = initial,
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var listed = await client.FieldDefinitionsClient.GetFieldListValuesAsync(new GetFieldListValuesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+                CollectionAssert.AreEqual(initial, (List<string>)listed.Values);
+
+                var replacement = new List<string> { "One", "Two", "Three", "Four" };
+                var afterReplace = await client.FieldDefinitionsClient.ReplaceFieldListValuesAsync(new ReplaceFieldListValuesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                    Request = new ReplaceListValuesRequest { Values = replacement },
+                }).ConfigureAwait(false);
+                CollectionAssert.AreEqual(replacement, (List<string>)afterReplace.Values);
+
+                // Clear via empty array
+                var afterClear = await client.FieldDefinitionsClient.ReplaceFieldListValuesAsync(new ReplaceFieldListValuesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                    Request = new ReplaceListValuesRequest { Values = new List<string>() },
+                }).ConfigureAwait(false);
+                Assert.AreEqual(0, afterClear.Values.Count);
+            }
+            finally
+            {
+                if (createdId > 0)
+                {
+                    await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task GetContainingTemplates_FieldNotInAnyTemplate_ReturnsEmpty()
+        {
+            string fieldName = UniqueName("client_test_orphan_field");
+            int createdId = 0;
+            try
+            {
+                var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest { Name = fieldName, FieldType = FieldType.String, Length = 10 }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var containing = await client.FieldDefinitionsClient.GetFieldContainingTemplatesAsync(new GetFieldContainingTemplatesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(containing);
+                Assert.AreEqual(0, containing.Count);
+            }
+            finally
+            {
+                if (createdId > 0)
+                {
+                    await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task GetAssignedEntryCount_BrandNewField_ReturnsZero()
+        {
+            string fieldName = UniqueName("client_test_unassigned_field");
+            int createdId = 0;
+            try
+            {
+                var created = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest { Name = fieldName, FieldType = FieldType.String, Length = 10 }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var count = await client.FieldDefinitionsClient.GetFieldAssignedEntryCountAsync(new GetFieldAssignedEntryCountParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(count);
+                Assert.AreEqual(0, count.Count);
+            }
+            finally
+            {
+                if (createdId > 0)
+                {
+                    await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = createdId,
+                    }).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
+++ b/tests/integration/FieldDefinitions/FieldDefinitionAdminTest.cs
@@ -117,6 +117,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
                 }).ConfigureAwait(false);
                 CollectionAssert.AreEqual(replacement, (List<string>)afterReplace.Values);
 
+                // Independent GET — proves the PUT persisted; same-request reads can mask a missing Save() (Trap 4).
+                var afterReplaceReread = await client.FieldDefinitionsClient.GetFieldListValuesAsync(new GetFieldListValuesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+                CollectionAssert.AreEqual(replacement, (List<string>)afterReplaceReread.Values);
+
                 // Clear via empty array
                 var afterClear = await client.FieldDefinitionsClient.ReplaceFieldListValuesAsync(new ReplaceFieldListValuesParameters
                 {
@@ -125,6 +133,13 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
                     Request = new ReplaceListValuesRequest { Values = new List<string>() },
                 }).ConfigureAwait(false);
                 Assert.AreEqual(0, afterClear.Values.Count);
+
+                var afterClearReread = await client.FieldDefinitionsClient.GetFieldListValuesAsync(new GetFieldListValuesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(0, afterClearReread.Values.Count);
             }
             finally
             {


### PR DESCRIPTION
## Summary

Regenerates the v2 dotnet client to pick up the 9 new Field Definition Admin endpoints introduced by the server PR for PRD §6.3.A (REQ-ADMIN-001..004 + REQ-ADMIN-004B). Companion PR for site-api-repository (TFS), US #666940.

New surface on `IFieldDefinitionsClient`:
- `CreateFieldDefinitionAsync` / `UpdateFieldDefinitionAsync` / `DeleteFieldDefinitionAsync`
- `GetFieldListValuesAsync` / `ReplaceFieldListValuesAsync`
- `GetFieldContainingTemplatesAsync` / `GetFieldAssignedEntryCountAsync`
- `GetFieldPropertiesAsync` / `UpdateFieldPropertiesAsync`

Plus new DTOs:
- `CreateFieldDefinitionRequest` / `UpdateFieldDefinitionRequest`
- `ReplaceListValuesRequest` / `ListValuesResponse`
- `AssignedEntryCountResponse`
- `FieldPropertiesResponse` / `UpdateFieldPropertiesRequest`

Five additive writable flags on `FieldDefinition`: `IsIndexed`, `IsIndexedForReporting`, `WarnIfBlank`, `HideListValues`, `AutoExtract`.

One pre-existing client-side fix included: `Extent = "All"` → `Extent = LockExtent.All` in `LockDocumentTest.cs` (LF server enum tightening surfaced by the regen — unrelated to 6.3.A but couldn't ship a clean regen without it).

## Test plan

- [x] Client unit tests pass (3/3)
- [x] **8/8 integration tests** pass against a local server with the companion server PR's branch (`FieldDefinitionAdminTest.cs`):
  - String lifecycle (Create/Update/Delete)
  - List field Replace round-trip (with independent GET re-reads)
  - GetContainingTemplates empty case
  - GetAssignedEntryCount zero case
  - Extended Properties Create/Get/Update round-trip
  - All 8 non-Blob FieldType enum values round-tripped
  - GET Properties on a fresh field documents what LFS-internal entries (if any) come back — empirically 0 on dev-CA
  - Server-side 400 validations surface as `ApiException` with `StatusCode==400` and parseable `ProblemDetails`

## Notes for reviewers

- Branch protection on `v2` requires PR even for admins (per the team convention); this respects that.
- Generated client regenerated via the standard `generate-client.ps1` script; one minor script-path quirk required a manual `Move-Item` from `src/` → `src/Clients/` after nswag — the regen-from-local helper on the preview-NuGet workflow branch handles this automatically.
- Companion PRs:
  - site-api-repository TFS PR #171879
  - lf-api-js (JS client regen) — follow-on

Related: PRD `notes/PRD - Repository REST API V2 Surface Expansion.md` §6.3.A