### PR TITLE
Regen client + integration tests for Template Definition admin (PRD 6.3.C)

### DIFF
--- a/.claude/skills/regen-dotnet-client/SKILL.md
+++ b/.claude/skills/regen-dotnet-client/SKILL.md
@@ -55,8 +55,10 @@ Use `py` or `C:\Python314\python.exe` — avoid `python3` (broken Windows Store 
 ```powershell
 .\generate-client\generate-client.ps1 `
     -input_folder generate-client `
-    -output_folder src
+    -output_folder src/Clients
 ```
+
+**Important:** `-output_folder` must be `src/Clients`, not `src`. The canonical location of the generated client is `src/Clients/RepositoryClients.cs`. If you pass `-output_folder src` the script will land the file at `src/RepositoryClients.cs` while `patch_optional_multipart.py` reads from the canonical `src/Clients/RepositoryClients.cs` — the patch silently runs against the stale file and the new regen ships unpatched. (Incident: 2026-05-25, during PRD 6.3.C regen on `bzajzon/template-definition-admin`.)
 
 The script:
 1. Invokes `nswag run generate-client/nswag.json` to produce `RepositoryClients.cs`.

--- a/generate-client/swagger.json
+++ b/generate-client/swagger.json
@@ -2111,7 +2111,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4047,7 +4047,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4158,7 +4158,7 @@
           "Entries"
         ],
         "summary": "Updates a document entry's electronic document and/or metadata from previously uploaded parts.",
-        "description": "- Updates a document entry from previously uploaded parts. The parts are assembled server-side into a single file that is then applied to the existing document.\n- The uploadId is obtained from the CreateMultipartUploadUrls response. The partETags are the ETag values returned by S3 when uploading each file chunk to the pre-signed upload URLs, and should be provided in the order of their associated upload URLs.\n- Use this endpoint when the file exceeds the upload size or time limits of the synchronous PATCH /Document endpoint.\n- The assembled file is applied as either the electronic document or image pages, following the same rules as the synchronous PATCH /Document:\n  - If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if `importAsElectronicDocument=true`, the file replaces the existing electronic document. For supported edoc formats, `pdfOptions.generatePages` additionally produces server-rendered image pages, and `pdfOptions.generateText` triggers text extraction from the document (or OCR when the source is image-based).\n  - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.\n- If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.\n- Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.\n- `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.\n- Required OAuth scope: repository.Write",
+        "description": "- Updates a document entry from previously uploaded parts. The parts are assembled server-side into a single file that is then applied to the existing document.\n- The uploadId is obtained from the CreateMultipartUploadUrls response. The partETags are the ETag values returned by S3 when uploading each file chunk to the pre-signed upload URLs, and should be provided in the order of their associated upload URLs.\n- Use this endpoint when the file exceeds the upload size or time limits of the synchronous PATCH /Document endpoint.\n- The assembled file is applied as either the electronic document or image pages, following the same rules as the synchronous PATCH /Document:\n  - If the file extension is not in {txt, tif, tiff, bmp, pcx, jpg, jpeg, gif, png}, or if `importAsElectronicDocument=true`, the file replaces the existing electronic document. For supported edoc formats, `pdfOptions.generatePages` additionally produces server-rendered image pages, and `pdfOptions.generateText` triggers text extraction from the document (or OCR when the source is image-based).\n  - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.\n- If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.\n- Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.\n- `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.\n- Required OAuth scope: repository.Write",
         "operationId": "UpdateDocumentUploadedParts",
         "parameters": [
           {
@@ -4591,7 +4591,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4736,7 +4736,7 @@
                   },
                   "imageFiles": {
                     "type": "array",
-                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
+                    "description": "Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).",
                     "items": {
                       "type": "string",
                       "format": "binary"
@@ -4834,8 +4834,8 @@
         "tags": [
           "Entries"
         ],
-        "summary": "Returns page information for pages in a document.",
-        "description": "- Returns a list of page properties including image dimensions, rotation angle, and content flags.\n- Optional parameter: pageRange (default empty). If no pageRange is specified, information for all pages is returned. The value should be a comma-separated string which contains non-overlapping single values, or page ranges. Ex: \"1,2,3\", \"1-3,5\", \"2-7,10-12.\"\n- Required OAuth scope: repository.Read",
+        "summary": "Returns page information for the pages of a document.",
+        "description": "- Returns a list of page properties including image dimensions, rotation angle, and content flags.\n- Pages are returned in ascending pageNumber order; that order is fixed and not configurable.\n- Default page size: 150. Allowed OData query options: Select | Count | SkipToken | Top | Prefer.\n- pageRange filters which pages are returned before paging is applied. Combine pageRange with $top/$skiptoken to paginate within a known range.\n- Required OAuth scope: repository.Read",
         "operationId": "ListPageInfos",
         "parameters": [
           {
@@ -4862,12 +4862,23 @@
           {
             "name": "pageRange",
             "in": "query",
-            "description": "The pages to retrieve information for.",
+            "description": "Optional comma-separated page numbers and ranges (e.g., \"1,3-5,8-10\"). Ranges must not overlap. When omitted, all pages are returned (subject to paging).",
             "schema": {
               "type": "string",
               "nullable": true
             },
             "x-position": 3
+          },
+          {
+            "name": "Prefer",
+            "x-originalName": "prefer",
+            "in": "header",
+            "description": "An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 4
           },
           {
             "name": "$select",
@@ -4877,15 +4888,15 @@
               "type": "string",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 5
           },
           {
-            "name": "$orderby",
+            "name": "$top",
             "in": "query",
-            "description": "Specifies the order in which items are returned. The maximum number of expressions is 5.",
+            "description": "Limits the number of items returned from a collection. The maximum value is 150.",
             "schema": {
-              "type": "string",
-              "nullable": true
+              "type": "integer",
+              "format": "int32"
             },
             "x-position": 6
           },
@@ -4901,14 +4912,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Successfully retrieved page information for the specified pages in the document.",
+            "description": "Successfully retrieved a paged listing of page information for the document.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/PageInfoResponse"
-                  }
+                  "$ref": "#/components/schemas/PageInfoCollectionResponse"
                 }
               }
             }
@@ -6427,7 +6435,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6540,7 +6548,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6646,7 +6654,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6740,6 +6748,26 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict. The request could not be completed due to the current state of the resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "423": {
+            "description": "Entry is locked",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -6751,7 +6779,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -6888,7 +6916,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -7004,6 +7032,16 @@
               }
             }
           },
+          "423": {
+            "description": "Entry is locked",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "429": {
             "description": "Rate limit is reached.",
             "content": {
@@ -7015,7 +7053,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -7130,7 +7168,7 @@
             }
           },
           "500": {
-            "description": "An unexpected server-side error occurred.",
+            "description": "Operation failed due to an internal server error. See error for details.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -8743,6 +8781,101 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Creates a new template definition in the repository.",
+        "description": "- Creates a new metadata template with the supplied scalar properties and (optionally) an initial set of field assignments.\n- Names must be unique within the repository; duplicate-name failures return 400.\n- Initial fields are appended in array order; each may carry per-template isRequired and localDescription. The repository-level field-definition properties are unaffected.\n- The template extended-properties bag (REQ-ADMIN-006B) cannot be set during create \u2014 follow up with PATCH /Properties.\n- Required OAuth scope: repository.Write",
+        "operationId": "CreateTemplate",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The template definition to create. Name is required.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTemplateRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the template definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}": {
@@ -8807,6 +8940,218 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Updates properties of an existing template definition (partial update).",
+        "description": "- Partial-update merge semantics. null = leave unchanged; \"\" = clear a string property.\n- To clear an existing color, set clearColor to true and leave color null. Supplying both is rejected with 400.\n- Field membership is managed via the AddTemplateField / RemoveTemplateField / MoveTemplateField endpoints.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateTemplate",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template to update.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The properties to change. Only non-null properties are applied; null leaves the property unchanged.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTemplateRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the template definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Deletes a template definition from the repository.",
+        "description": "- Deletes the specified template definition. Behavior when the template is assigned to entries mirrors the underlying repository server response \u2014 if rejected, the response surfaces the server error.\n- Required OAuth scope: repository.Write",
+        "operationId": "DeleteTemplate",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template to delete.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the template definition."
           },
           "400": {
             "description": "Invalid or bad request.",
@@ -9158,6 +9503,801 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/AssignedEntryCount": {
+      "get": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Returns the count of entries currently assigned to the specified template definition.",
+        "description": "- Useful for impact analysis before performing destructive operations on the template.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetTemplateAssignedEntryCount",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the assigned entry count for the template.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignedEntryCountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Properties": {
+      "get": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Gets the extended-properties bag for a template definition.",
+        "description": "- The bag is opaque: keys are WebDAV-style identifiers used by admin tooling and migration utilities, and values are strings consumers interpret.\n- The response may include LFS-internal entries (RA-managed flags, audit metadata, etc.) alongside caller-set keys. Treat unrecognized keys as read-only system data and avoid round-tripping them on UpdateTemplateProperties unless their semantics are known.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetTemplateProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the template extended-properties bag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplatePropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Partially updates the extended-properties bag for a template definition.",
+        "description": "- Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.\n- Empty set and empty remove is a no-op and returns the current bag.\n- Returns the full property bag after the change.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateTemplateProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTemplatePropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the template extended-properties bag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplatePropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields": {
+      "post": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Adds a field to a template.",
+        "description": "- The field definition must already exist in the repository.\n- Per-template properties do not affect the repository-level field-definition properties.\n- Required OAuth scope: repository.Write",
+        "operationId": "AddTemplateField",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The field to add. fieldName is required. Optional position (1-based) inserts at that position; omit to append. Optional per-template isRequired and localDescription apply only to this template.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddTemplateFieldRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully added the field to the template."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/{fieldName}": {
+      "patch": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Updates per-template properties for a field assignment on a template.",
+        "description": "- Affects only the field's behavior on this specific template.\n- The repository-level field-definition properties are unchanged; use the FieldDefinitions admin endpoints for those.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateTemplateFieldProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "required": true,
+            "description": "The name of the field whose per-template properties to update. URL-decoded server-side.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 3
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The per-template properties to change. Null = leave unchanged; empty string clears localDescription.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTemplateFieldPropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 4
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully updated the per-template properties for the field assignment."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Removes a field from a template.",
+        "description": "- Field values already assigned to entries using this template are not affected \u2014 RA removes only the binding of the field to the template definition.\n- The field definition itself is not deleted; only the template assignment is removed.\n- Required OAuth scope: repository.Write",
+        "operationId": "RemoveTemplateField",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "required": true,
+            "description": "The name of the field to remove. URL-decoded server-side.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully removed the field from the template."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/Move": {
+      "post": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Moves a field to a new position within a template.",
+        "description": "- The field must already be part of the template.\n- newPosition must be between 1 and the current field count, inclusive.\n- Required OAuth scope: repository.Write",
+        "operationId": "MoveTemplateField",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The field to move and the new 1-based position.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveTemplateFieldRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully moved the field to the new position in the template."
           },
           "400": {
             "description": "Invalid or bad request.",
@@ -10634,12 +11774,12 @@
               },
               "lockedBy": {
                 "type": "string",
-                "description": "The account name of the persistent lock holder. Null if the document is not locked.",
+                "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the persistent lock holder. Null if the document is not locked.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.\nTo test whether the current authenticated user holds the lock, use IsLockedByAnotherUser; it compares stable principal identifiers internally.",
                 "nullable": true
               },
               "isLockedByAnotherUser": {
                 "type": "boolean",
-                "description": "A boolean indicating if the document is locked by a user other than the authenticated user.\nFalse if the document is not locked or is locked by the authenticated user.\nOnly populated on single-entry GET, not in listing results."
+                "description": "A boolean indicating if the document is locked by a user other than the authenticated user.\nFalse if the document is not locked or is locked by the authenticated user.\nComputed from a stable principal identifier comparison, not from LockedBy.\nOnly populated on single-entry GET, not in listing results."
               },
               "currentVersion": {
                 "type": "integer",
@@ -10648,12 +11788,12 @@
               },
               "checkedOutBy": {
                 "type": "string",
-                "description": "The account name of the user who checked out the document. Null if the document is not checked out.",
+                "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the user who checked out the document. Null if the document is not checked out.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.\nTo test whether the current authenticated user holds the checkout, use IsCheckedOutByAnotherUser; it compares stable principal identifiers internally.",
                 "nullable": true
               },
               "isCheckedOutByAnotherUser": {
                 "type": "boolean",
-                "description": "A boolean indicating if the document is checked out by a user other than the authenticated user.\nFalse if the document is not checked out or is checked out by the authenticated user.\nOnly populated on single-entry GET, not in listing results."
+                "description": "A boolean indicating if the document is checked out by a user other than the authenticated user.\nFalse if the document is not checked out or is checked out by the authenticated user.\nComputed from a stable principal identifier comparison, not from CheckedOutBy.\nOnly populated on single-entry GET, not in listing results."
               }
             }
           }
@@ -11440,6 +12580,32 @@
           }
         }
       },
+      "PageInfoCollectionResponse": {
+        "type": "object",
+        "description": "Response containing a collection of PageInfoResponse.",
+        "additionalProperties": false,
+        "properties": {
+          "@odata.nextLink": {
+            "type": "string",
+            "description": "A URL to retrieve the next page of the requested collection.",
+            "nullable": true
+          },
+          "@odata.count": {
+            "type": "integer",
+            "description": "The total count of items within a collection.",
+            "format": "int32",
+            "nullable": true
+          },
+          "value": {
+            "type": "array",
+            "description": "Gets or sets the OData response content in the \"value\".",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/PageInfoResponse"
+            }
+          }
+        }
+      },
       "PageInfoResponse": {
         "type": "object",
         "additionalProperties": false,
@@ -11577,7 +12743,7 @@
           },
           "owner": {
             "type": "string",
-            "description": "The account name of the lock owner (e.g., \"DOMAIN\\user\").",
+            "description": "Display name (account name, e.g. \"DOMAIN\\user\") of the lock owner.\nSame value reported as lockedBy on Document for the same lock.\nAccount renames change this value over time \u2014 do not use for stable identity comparisons.",
             "nullable": true
           },
           "comment": {
@@ -11618,11 +12784,55 @@
             "nullable": true
           },
           "extent": {
-            "type": "string",
-            "description": "The lock extent. Valid values: \"Page\", \"Edoc\", \"Metadata\", \"All\". Defaults to \"All\".",
-            "nullable": true
+            "description": "The lock extent. Defaults to All when omitted.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LockExtent"
+              }
+            ]
           }
         }
+      },
+      "LockExtent": {
+        "type": "string",
+        "description": "The portion of a document that a persistent lock covers.",
+        "x-enum-names": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ],
+        "x-enum-varnames": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ],
+        "x-enumNames": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Page",
+          "Edoc",
+          "Metadata",
+          "All"
+        ]
       },
       "CheckOutDocumentRequest": {
         "type": "object",
@@ -12342,6 +13552,10 @@
             "type": "integer",
             "description": "The number of field definitions assigned to the template definition.",
             "format": "int32"
+          },
+          "isAutoAssignable": {
+            "type": "boolean",
+            "description": "Whether the template is eligible for automatic assignment by Cloud auto-classification."
           }
         }
       },
@@ -12426,6 +13640,11 @@
                 "type": "string",
                 "description": "The name of field group.",
                 "nullable": true
+              },
+              "localDescription": {
+                "type": "string",
+                "description": "The per-template description for this field assignment. Distinct from the field\ndefinition's repository-level description; set via AddTemplateField /\nUpdateTemplateFieldProperties.",
+                "nullable": true
               }
             }
           }
@@ -12444,6 +13663,224 @@
               "type": "integer",
               "format": "int32"
             }
+          }
+        }
+      },
+      "CreateTemplateRequest": {
+        "type": "object",
+        "description": "Request body for creating a new template definition. Name is required; all other\nproperties are optional and fall back to repository defaults when omitted.",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the template. Required. Must be unique within the repository."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the template.",
+            "nullable": true
+          },
+          "color": {
+            "description": "The color assigned to the template. Omit (or set null) for no color.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LFColor"
+              }
+            ]
+          },
+          "isAutoAssignable": {
+            "type": "boolean",
+            "description": "Whether the template is eligible for automatic assignment by Cloud auto-classification.\nDefaults to false when omitted.",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "description": "Optional initial field assignments. Order is preserved (each entry is appended\nin array order; the resulting position is 1-based). Each entry may carry the\nper-template isRequired and localDescription properties.\nNote: extended properties (the WebDAV-keyed bag) cannot be set during create\nbecause RepositoryAccess does not expose an atomic create-with-properties path\nfor templates. To set initial properties, follow Create with a PATCH /Properties\ncall against the returned template ID.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/TemplateFieldAssignment"
+            }
+          }
+        }
+      },
+      "TemplateFieldAssignment": {
+        "type": "object",
+        "description": "A single field assignment used in Fields.",
+        "additionalProperties": false,
+        "required": [
+          "fieldName"
+        ],
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "The name of an existing field definition to assign to the template. Required."
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required for entries assigned to this template specifically.\nDistinct from the repository-level IsRequired on the field definition.",
+            "nullable": true
+          },
+          "localDescription": {
+            "type": "string",
+            "description": "The per-template description for this field assignment.",
+            "nullable": true
+          }
+        }
+      },
+      "UpdateTemplateRequest": {
+        "type": "object",
+        "description": "Request body for partial-update of an existing template definition. Every property\nis optional.\nnull = leave the property unchanged.\nEmpty string (\"\") on a string property = clear the value.\nTo clear an existing color, set ClearColor to true and leave Color null. Supplying both Color and ClearColor=true is rejected with 400.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The new name of the template. Must be unique within the repository.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the template.",
+            "nullable": true
+          },
+          "color": {
+            "description": "The new color for the template. Omit to leave unchanged.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LFColor"
+              }
+            ]
+          },
+          "clearColor": {
+            "type": "boolean",
+            "description": "Set to true to clear the template's existing color. Mutually exclusive with Color.",
+            "nullable": true
+          },
+          "isAutoAssignable": {
+            "type": "boolean",
+            "description": "Whether the template is eligible for automatic assignment by Cloud auto-classification.",
+            "nullable": true
+          }
+        }
+      },
+      "AssignedEntryCountResponse": {
+        "type": "object",
+        "description": "The number of entries that have a value assigned for a given field definition,\nor that are currently assigned to a given template definition.",
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "type": "integer",
+            "description": "The count of entries currently using this field or template.",
+            "format": "int32"
+          }
+        }
+      },
+      "TemplatePropertiesResponse": {
+        "type": "object",
+        "description": "Response body for the extended-properties bag on a template definition. The bag is\nopaque: keys are WebDAV-style identifiers used by admin tooling and migration\nutilities; values are strings consumers interpret. The response may include\nLFS-internal entries (e.g. RA-managed flags) alongside caller-set keys; callers\nshould treat unrecognized keys as read-only system data.",
+        "additionalProperties": false,
+        "properties": {
+          "properties": {
+            "type": "object",
+            "description": "The full set of extended properties currently set on the template.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UpdateTemplatePropertiesRequest": {
+        "type": "object",
+        "description": "Request body for partially updating the extended-properties bag on a template\ndefinition. Entries in Set are written (creating or overwriting).\nEntries in Remove are deleted. Properties not mentioned in either\nare left unchanged.",
+        "additionalProperties": false,
+        "properties": {
+          "set": {
+            "type": "object",
+            "description": "Properties to set. Keys absent here are not modified.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "remove": {
+            "type": "array",
+            "description": "Property keys to remove. Keys not currently set are ignored.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AddTemplateFieldRequest": {
+        "type": "object",
+        "description": "Request body for adding an existing field definition to a template.",
+        "additionalProperties": false,
+        "required": [
+          "fieldName"
+        ],
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "The name of an existing field definition to assign to the template. Required."
+          },
+          "position": {
+            "type": "integer",
+            "description": "The 1-based position at which to insert the field. Omit (or set null) to append\nto the end of the template. Values less than 1 or greater than the current\nfield count + 1 are rejected with 400.",
+            "format": "int32",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required for entries assigned to this template specifically.\nDistinct from the repository-level IsRequired on the field definition.",
+            "nullable": true
+          },
+          "localDescription": {
+            "type": "string",
+            "description": "The per-template description for this field assignment. Distinct from the\nfield definition's repository-level description.",
+            "nullable": true
+          }
+        }
+      },
+      "UpdateTemplateFieldPropertiesRequest": {
+        "type": "object",
+        "description": "Request body for updating per-template properties on a field assignment that is\nalready part of a template. Repository-level field-definition properties are\nunaffected by this endpoint \u2014 those go through the FieldDefinitions admin endpoints.\nnull = leave the property unchanged.\nEmpty string (\"\") on LocalDescription clears the value.",
+        "additionalProperties": false,
+        "properties": {
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required for entries assigned to this template specifically.",
+            "nullable": true
+          },
+          "localDescription": {
+            "type": "string",
+            "description": "The per-template description for this field assignment.",
+            "nullable": true
+          }
+        }
+      },
+      "MoveTemplateFieldRequest": {
+        "type": "object",
+        "description": "Request body for moving an existing field within a template to a new position.",
+        "additionalProperties": false,
+        "required": [
+          "fieldName",
+          "newPosition"
+        ],
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "The name of the field to move. Required. Must already be part of the template."
+          },
+          "newPosition": {
+            "type": "integer",
+            "description": "The 1-based target position. Required. Values less than 1 or greater than the\ncurrent field count are rejected with 400.",
+            "format": "int32"
           }
         }
       }

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -2554,7 +2554,7 @@ namespace Laserfiche.Repository.Api.Client
         ///   - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.<br/>
         /// - If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.<br/>
         /// - Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.<br/>
-        /// - `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.<br/>
+        /// - `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.<br/>
         /// - Required OAuth scope: repository.Write
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -4289,7 +4289,9 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file != null)
+                        if (file == null)
+                            throw new ArgumentNullException("parameters.File");
+                        else
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -4305,7 +4307,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -4340,7 +4344,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file != null)
+                                if (file == null)
+                                    throw new ArgumentNullException("parameters.File");
+                                else
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -4356,7 +4362,9 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -6894,7 +6902,9 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file != null)
+                        if (file == null)
+                            throw new ArgumentNullException("parameters.File");
+                        else
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -6902,13 +6912,17 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_file_, "file", file.FileName ?? "file");
                             }
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -6943,7 +6957,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file != null)
+                                if (file == null)
+                                    throw new ArgumentNullException("parameters.File");
+                                else
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -6951,13 +6967,17 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_file_, "file", file.FileName ?? "file");
                                     }
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -7131,7 +7151,7 @@ namespace Laserfiche.Repository.Api.Client
         ///   - Otherwise (image extension with `importAsElectronicDocument=false`), the file is imported as image pages. `pdfOptions.generateText` triggers OCR for the resulting pages.<br/>
         /// - If `metadata` is provided, it additively updates the template, fields, tags, and links. Existing values not mentioned in the request are preserved.<br/>
         /// - Returns 202 Accepted with a task ID. Poll the task endpoint for progress and completion.<br/>
-        /// - `imageFiles`, `generateImagePagesText`, and the `overwriteContent` query parameter are not supported on this endpoint; use the synchronous PATCH /Document to append image pages, OCR them automatically, or replace metadata wholesale.<br/>
+        /// - `imageFiles` and `generateImagePagesText` are not supported on this endpoint; use the synchronous PATCH /Document to append image pages or OCR them automatically. Use PUT /Document/Pages to replace existing pages.<br/>
         /// - Required OAuth scope: repository.Write
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -7785,13 +7805,17 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -7826,13 +7850,17 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -8040,13 +8068,17 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles != null)
+                        if (imageFiles == null)
+                            throw new ArgumentNullException("parameters.ImageFiles");
+                        else
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -8081,13 +8113,17 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles != null)
+                                if (imageFiles == null)
+                                    throw new ArgumentNullException("parameters.ImageFiles");
+                                else
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -8485,7 +8521,9 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (imageFile != null)
+                        if (imageFile == null)
+                            throw new ArgumentNullException("parameters.ImageFile");
+                        else
                         {
                                 var content_imageFile_ = new StreamContent(imageFile.Data);
                                 if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -8493,7 +8531,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                             }
 
-                        if (request != null)
+                        if (request == null)
+                            throw new ArgumentNullException("parameters.Request");
+                        else
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
@@ -8523,7 +8563,9 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (imageFile != null)
+                                if (imageFile == null)
+                                    throw new ArgumentNullException("parameters.ImageFile");
+                                else
                                 {
                                         var content_imageFile_ = new StreamContent(imageFile.Data);
                                         if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -8531,7 +8573,9 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                                     }
 
-                                if (request != null)
+                                if (request == null)
+                                    throw new ArgumentNullException("parameters.Request");
+                                else
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
@@ -10982,6 +11026,26 @@ namespace Laserfiche.Repository.Api.Client
                     throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
                 }
                 else
+                if (status_ == 409)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 423)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
                 if (status_ == 429)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
@@ -11330,6 +11394,16 @@ namespace Laserfiche.Repository.Api.Client
                 }
                 else
                 if (status_ == 409)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 423)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                     if (objectResponse_.Object == null)
@@ -11857,7 +11931,7 @@ namespace Laserfiche.Repository.Api.Client
         public ImportEntryRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -12295,7 +12369,7 @@ namespace Laserfiche.Repository.Api.Client
         public UpdateDocumentRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -12394,7 +12468,7 @@ namespace Laserfiche.Repository.Api.Client
         public PagesContentRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -12424,7 +12498,7 @@ namespace Laserfiche.Repository.Api.Client
         public PagesContentRequest Request { get; set; } = null;
 
         /// <summary>
-        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. On UpdateDocument, existing pages are preserved by default and deleted first when overwriteContent=true. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
+        /// Optional. Up to 10 image files (100 MB aggregate) that are appended as image pages. Use PUT /Document/Pages to replace existing pages instead of appending. Set generateImagePagesText=false in the request body to skip OCR for these pages (default: true).
         /// </summary>
         public IEnumerable<FileParameter> ImageFiles { get; set; } = null;
 
@@ -15878,6 +15952,22 @@ namespace Laserfiche.Repository.Api.Client
         Task<TemplateDefinitionCollectionResponse> ListTemplateDefinitionsAsync(ListTemplateDefinitionsParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Creates a new template definition in the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Creates a new metadata template with the supplied scalar properties and (optionally) an initial set of field assignments.<br/>
+        /// - Names must be unique within the repository; duplicate-name failures return 400.<br/>
+        /// - Initial fields are appended in array order; each may carry per-template isRequired and localDescription. The repository-level field-definition properties are unaffected.<br/>
+        /// - The template extended-properties bag (REQ-ADMIN-006B) cannot be set during create — follow up with PATCH /Properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully created the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplateDefinition> CreateTemplateAsync(CreateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Returns a single template definition object.
         /// </summary>
         /// <remarks>
@@ -15891,6 +15981,34 @@ namespace Laserfiche.Repository.Api.Client
         /// <returns>Successfully found and returned specified template.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task<TemplateDefinition> GetTemplateDefinitionAsync(GetTemplateDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Updates properties of an existing template definition (partial update).
+        /// </summary>
+        /// <remarks>
+        /// - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.<br/>
+        /// - To clear an existing color, set clearColor to true and leave color null. Supplying both is rejected with 400.<br/>
+        /// - Field membership is managed via the AddTemplateField / RemoveTemplateField / MoveTemplateField endpoints.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplateDefinition> UpdateTemplateAsync(UpdateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Deletes a template definition from the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Deletes the specified template definition. Behavior when the template is assigned to entries mirrors the underlying repository server response — if rejected, the response surfaces the server error.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully deleted the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task DeleteTemplateAsync(DeleteTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Returns the field definitions assigned to a template definition (by template definition ID).
@@ -15921,6 +16039,104 @@ namespace Laserfiche.Repository.Api.Client
         /// <returns>Returned list of field definitions for specified template.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task<TemplateFieldDefinitionCollectionResponse> ListTemplateFieldDefinitionsByTemplateNameAsync(ListTemplateFieldDefinitionsByTemplateNameParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns the count of entries currently assigned to the specified template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Useful for impact analysis before performing destructive operations on the template.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the assigned entry count for the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<AssignedEntryCountResponse> GetTemplateAssignedEntryCountAsync(GetTemplateAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Gets the extended-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - The bag is opaque: keys are WebDAV-style identifiers used by admin tooling and migration utilities, and values are strings consumers interpret.<br/>
+        /// - The response may include LFS-internal entries (RA-managed flags, audit metadata, etc.) alongside caller-set keys. Treat unrecognized keys as read-only system data and avoid round-tripping them on UpdateTemplateProperties unless their semantics are known.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplatePropertiesResponse> GetTemplatePropertiesAsync(GetTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Partially updates the extended-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
+        /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
+        /// - Returns the full property bag after the change.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplatePropertiesResponse> UpdateTemplatePropertiesAsync(UpdateTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Adds a field to a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field definition must already exist in the repository.<br/>
+        /// - Per-template properties do not affect the repository-level field-definition properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully added the field to the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task AddTemplateFieldAsync(AddTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Updates per-template properties for a field assignment on a template.
+        /// </summary>
+        /// <remarks>
+        /// - Affects only the field's behavior on this specific template.<br/>
+        /// - The repository-level field-definition properties are unchanged; use the FieldDefinitions admin endpoints for those.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the per-template properties for the field assignment.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task UpdateTemplateFieldPropertiesAsync(UpdateTemplateFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Removes a field from a template.
+        /// </summary>
+        /// <remarks>
+        /// - Field values already assigned to entries using this template are not affected — RA removes only the binding of the field to the template definition.<br/>
+        /// - The field definition itself is not deleted; only the template assignment is removed.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully removed the field from the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task RemoveTemplateFieldAsync(RemoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Moves a field to a new position within a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field must already be part of the template.<br/>
+        /// - newPosition must be between 1 and the current field count, inclusive.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully moved the field to the new position in the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task MoveTemplateFieldAsync(MoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
     }
 
@@ -16143,6 +16359,157 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         /// <summary>
+        /// Creates a new template definition in the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Creates a new metadata template with the supplied scalar properties and (optionally) an initial set of field assignments.<br/>
+        /// - Names must be unique within the repository; duplicate-name failures return 400.<br/>
+        /// - Initial fields are appended in array order; each may carry per-template isRequired and localDescription. The repository-level field-definition properties are unaffected.<br/>
+        /// - The template extended-properties bag (REQ-ADMIN-006B) cannot be set during create — follow up with PATCH /Properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully created the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplateDefinition> CreateTemplateAsync(CreateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await CreateTemplateSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplateDefinition> CreateTemplateSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplateDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Returns a single template definition object.
         /// </summary>
         /// <remarks>
@@ -16237,6 +16604,322 @@ namespace Laserfiche.Repository.Api.Client
                         throw ApiExceptionExtensions.Create(status_, headers_, null);
                     }
                     return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Updates properties of an existing template definition (partial update).
+        /// </summary>
+        /// <remarks>
+        /// - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.<br/>
+        /// - To clear an existing color, set clearColor to true and leave color null. Supplying both is rejected with 400.<br/>
+        /// - Field membership is managed via the AddTemplateField / RemoveTemplateField / MoveTemplateField endpoints.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplateDefinition> UpdateTemplateAsync(UpdateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await UpdateTemplateSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplateDefinition> UpdateTemplateSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplateDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Deletes a template definition from the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Deletes the specified template definition. Behavior when the template is assigned to entries mirrors the underlying repository server response — if rejected, the response surfaces the server error.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully deleted the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task DeleteTemplateAsync(DeleteTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("DELETE");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await DeleteTemplateSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task DeleteTemplateSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
                 }
                 else
                 if (status_ == 400)
@@ -16698,6 +17381,1145 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
+        /// <summary>
+        /// Returns the count of entries currently assigned to the specified template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Useful for impact analysis before performing destructive operations on the template.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the assigned entry count for the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<AssignedEntryCountResponse> GetTemplateAssignedEntryCountAsync(GetTemplateAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var select = parameters.Select;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/AssignedEntryCount"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/AssignedEntryCount");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetTemplateAssignedEntryCountSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<AssignedEntryCountResponse> GetTemplateAssignedEntryCountSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<AssignedEntryCountResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Gets the extended-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - The bag is opaque: keys are WebDAV-style identifiers used by admin tooling and migration utilities, and values are strings consumers interpret.<br/>
+        /// - The response may include LFS-internal entries (RA-managed flags, audit metadata, etc.) alongside caller-set keys. Treat unrecognized keys as read-only system data and avoid round-tripping them on UpdateTemplateProperties unless their semantics are known.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplatePropertiesResponse> GetTemplatePropertiesAsync(GetTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var select = parameters.Select;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Properties"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Properties");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetTemplatePropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplatePropertiesResponse> GetTemplatePropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplatePropertiesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Partially updates the extended-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
+        /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
+        /// - Returns the full property bag after the change.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplatePropertiesResponse> UpdateTemplatePropertiesAsync(UpdateTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Properties"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Properties");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await UpdateTemplatePropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplatePropertiesResponse> UpdateTemplatePropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplatePropertiesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Adds a field to a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field definition must already exist in the repository.<br/>
+        /// - Per-template properties do not affect the repository-level field-definition properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully added the field to the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task AddTemplateFieldAsync(AddTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await AddTemplateFieldSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task AddTemplateFieldSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Updates per-template properties for a field assignment on a template.
+        /// </summary>
+        /// <remarks>
+        /// - Affects only the field's behavior on this specific template.<br/>
+        /// - The repository-level field-definition properties are unchanged; use the FieldDefinitions admin endpoints for those.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the per-template properties for the field assignment.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task UpdateTemplateFieldPropertiesAsync(UpdateTemplateFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var fieldName = parameters.FieldName;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (fieldName == null)
+                throw new ArgumentNullException("parameters.FieldName");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/{fieldName}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldName, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await UpdateTemplateFieldPropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task UpdateTemplateFieldPropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Removes a field from a template.
+        /// </summary>
+        /// <remarks>
+        /// - Field values already assigned to entries using this template are not affected — RA removes only the binding of the field to the template definition.<br/>
+        /// - The field definition itself is not deleted; only the template assignment is removed.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully removed the field from the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task RemoveTemplateFieldAsync(RemoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var fieldName = parameters.FieldName;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (fieldName == null)
+                throw new ArgumentNullException("parameters.FieldName");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/{fieldName}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldName, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("DELETE");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await RemoveTemplateFieldSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task RemoveTemplateFieldSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Moves a field to a new position within a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field must already be part of the template.<br/>
+        /// - newPosition must be between 1 and the current field count, inclusive.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully moved the field to the new position in the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task MoveTemplateFieldAsync(MoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/Move"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields/Move");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await MoveTemplateFieldSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task MoveTemplateFieldSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)
@@ -16864,6 +18686,24 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.CreateTemplateAsync(CreateTemplateParameters, CancellationToken)">CreateTemplate</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CreateTemplateParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The template definition to create. Name is required.
+        /// </summary>
+        public CreateTemplateRequest Request { get; set; }
+
+    }
+
+    /// <summary>
     /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.GetTemplateDefinitionAsync(GetTemplateDefinitionParameters, CancellationToken)">GetTemplateDefinition</see>.
     /// </summary>
     [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -16888,6 +18728,47 @@ namespace Laserfiche.Repository.Api.Client
         /// Limits the properties returned in the result.
         /// </summary>
         public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.UpdateTemplateAsync(UpdateTemplateParameters, CancellationToken)">UpdateTemplate</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template to update.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The properties to change. Only non-null properties are applied; null leaves the property unchanged.
+        /// </summary>
+        public UpdateTemplateRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.DeleteTemplateAsync(DeleteTemplateParameters, CancellationToken)">DeleteTemplate</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class DeleteTemplateParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template to delete.
+        /// </summary>
+        public int TemplateId { get; set; }
 
     }
 
@@ -16994,6 +18875,172 @@ namespace Laserfiche.Repository.Api.Client
         /// Indicates whether the total count of items within a collection are returned in the result.
         /// </summary>
         public bool? Count { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.GetTemplateAssignedEntryCountAsync(GetTemplateAssignedEntryCountParameters, CancellationToken)">GetTemplateAssignedEntryCount</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetTemplateAssignedEntryCountParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.GetTemplatePropertiesAsync(GetTemplatePropertiesParameters, CancellationToken)">GetTemplateProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetTemplatePropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.UpdateTemplatePropertiesAsync(UpdateTemplatePropertiesParameters, CancellationToken)">UpdateTemplateProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplatePropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.
+        /// </summary>
+        public UpdateTemplatePropertiesRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.AddTemplateFieldAsync(AddTemplateFieldParameters, CancellationToken)">AddTemplateField</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AddTemplateFieldParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The field to add. fieldName is required. Optional position (1-based) inserts at that position; omit to append. Optional per-template isRequired and localDescription apply only to this template.
+        /// </summary>
+        public AddTemplateFieldRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.UpdateTemplateFieldPropertiesAsync(UpdateTemplateFieldPropertiesParameters, CancellationToken)">UpdateTemplateFieldProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateFieldPropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The name of the field whose per-template properties to update. URL-decoded server-side.
+        /// </summary>
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// The per-template properties to change. Null = leave unchanged; empty string clears localDescription.
+        /// </summary>
+        public UpdateTemplateFieldPropertiesRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.RemoveTemplateFieldAsync(RemoveTemplateFieldParameters, CancellationToken)">RemoveTemplateField</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class RemoveTemplateFieldParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The name of the field to remove. URL-decoded server-side.
+        /// </summary>
+        public string FieldName { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.MoveTemplateFieldAsync(MoveTemplateFieldParameters, CancellationToken)">MoveTemplateField</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MoveTemplateFieldParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The field to move and the new 1-based position.
+        /// </summary>
+        public MoveTemplateFieldRequest Request { get; set; }
 
     }
 
@@ -18182,7 +20229,9 @@ namespace Laserfiche.Repository.Api.Client
         public bool IsLocked { get; set; }
 
         /// <summary>
-        /// The account name of the persistent lock holder. Null if the document is not locked.
+        /// Display name (account name, e.g. "DOMAIN\user") of the persistent lock holder. Null if the document is not locked.<br/>
+        /// Account renames change this value over time — do not use for stable identity comparisons.<br/>
+        /// To test whether the current authenticated user holds the lock, use IsLockedByAnotherUser; it compares stable principal identifiers internally.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("lockedBy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string LockedBy { get; set; }
@@ -18190,6 +20239,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// A boolean indicating if the document is locked by a user other than the authenticated user.<br/>
         /// False if the document is not locked or is locked by the authenticated user.<br/>
+        /// Computed from a stable principal identifier comparison, not from LockedBy.<br/>
         /// Only populated on single-entry GET, not in listing results.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("isLockedByAnotherUser", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -18202,7 +20252,9 @@ namespace Laserfiche.Repository.Api.Client
         public int CurrentVersion { get; set; }
 
         /// <summary>
-        /// The account name of the user who checked out the document. Null if the document is not checked out.
+        /// Display name (account name, e.g. "DOMAIN\user") of the user who checked out the document. Null if the document is not checked out.<br/>
+        /// Account renames change this value over time — do not use for stable identity comparisons.<br/>
+        /// To test whether the current authenticated user holds the checkout, use IsCheckedOutByAnotherUser; it compares stable principal identifiers internally.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("checkedOutBy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string CheckedOutBy { get; set; }
@@ -18210,6 +20262,7 @@ namespace Laserfiche.Repository.Api.Client
         /// <summary>
         /// A boolean indicating if the document is checked out by a user other than the authenticated user.<br/>
         /// False if the document is not checked out or is checked out by the authenticated user.<br/>
+        /// Computed from a stable principal identifier comparison, not from CheckedOutBy.<br/>
         /// Only populated on single-entry GET, not in listing results.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("isCheckedOutByAnotherUser", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -18638,32 +20691,6 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
-    /// Response containing a collection of PageInfoResponse.
-    /// </summary>
-    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public partial class PageInfoCollectionResponse
-    {
-        /// <summary>
-        /// A URL to retrieve the next page of the requested collection.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("@odata.nextLink", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string OdataNextLink { get; set; }
-
-        /// <summary>
-        /// The total count of items within a collection.
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? OdataCount { get; set; }
-
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
-        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public IList<PageInfoResponse> Value { get; set; }
-
-    }
-
-    /// <summary>
     /// Represents a link between a source entry and a target entry.
     /// </summary>
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -19004,6 +21031,32 @@ namespace Laserfiche.Repository.Api.Client
 
     }
 
+    /// <summary>
+    /// Response containing a collection of PageInfoResponse.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class PageInfoCollectionResponse
+    {
+        /// <summary>
+        /// A URL to retrieve the next page of the requested collection.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("@odata.nextLink", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string OdataNextLink { get; set; }
+
+        /// <summary>
+        /// The total count of items within a collection.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? OdataCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the OData response content in the "value".
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<PageInfoResponse> Value { get; set; }
+
+    }
+
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class PageInfoResponse
     {
@@ -19118,7 +21171,9 @@ namespace Laserfiche.Repository.Api.Client
         public string LockToken { get; set; }
 
         /// <summary>
-        /// The account name of the lock owner (e.g., "DOMAIN\user").
+        /// Display name (account name, e.g. "DOMAIN\user") of the lock owner.<br/>
+        /// Same value reported as lockedBy on Document for the same lock.<br/>
+        /// Account renames change this value over time — do not use for stable identity comparisons.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("owner", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Owner { get; set; }
@@ -19168,10 +21223,32 @@ namespace Laserfiche.Repository.Api.Client
         public string Comment { get; set; }
 
         /// <summary>
-        /// The lock extent. Valid values: "Page", "Edoc", "Metadata", "All". Defaults to "All".
+        /// The lock extent. Defaults to All when omitted.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("extent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Extent { get; set; }
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public LockExtent? Extent { get; set; }
+
+    }
+
+    /// <summary>
+    /// The portion of a document that a persistent lock covers.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum LockExtent
+    {
+
+        [EnumMember(Value = @"Page")]
+        Page = 0,
+
+        [EnumMember(Value = @"Edoc")]
+        Edoc = 1,
+
+        [EnumMember(Value = @"Metadata")]
+        Metadata = 2,
+
+        [EnumMember(Value = @"All")]
+        All = 3,
 
     }
 
@@ -19806,6 +21883,12 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("fieldCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int FieldCount { get; set; }
 
+        /// <summary>
+        /// Whether the template is eligible for automatic assignment by Cloud auto-classification.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isAutoAssignable", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsAutoAssignable { get; set; }
+
     }
 
     /// <summary>
@@ -19890,6 +21973,14 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("groupName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string GroupName { get; set; }
 
+        /// <summary>
+        /// The per-template description for this field assignment. Distinct from the field<br/>
+        /// definition's repository-level description; set via AddTemplateField /<br/>
+        /// UpdateTemplateFieldProperties.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
     }
 
     /// <summary>
@@ -19903,6 +21994,258 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("ancestors", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<int> Ancestors { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for creating a new template definition. Name is required; all other<br/>
+    /// properties are optional and fall back to repository defaults when omitted.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CreateTemplateRequest
+    {
+        /// <summary>
+        /// The name of the template. Required. Must be unique within the repository.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The description of the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The color assigned to the template. Omit (or set null) for no color.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public LFColor Color { get; set; }
+
+        /// <summary>
+        /// Whether the template is eligible for automatic assignment by Cloud auto-classification.<br/>
+        /// Defaults to false when omitted.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isAutoAssignable", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsAutoAssignable { get; set; }
+
+        /// <summary>
+        /// Optional initial field assignments. Order is preserved (each entry is appended<br/>
+        /// in array order; the resulting position is 1-based). Each entry may carry the<br/>
+        /// per-template isRequired and localDescription properties.<br/>
+        /// Note: extended properties (the WebDAV-keyed bag) cannot be set during create<br/>
+        /// because RepositoryAccess does not expose an atomic create-with-properties path<br/>
+        /// for templates. To set initial properties, follow Create with a PATCH /Properties<br/>
+        /// call against the returned template ID.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fields", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<TemplateFieldAssignment> Fields { get; set; }
+
+    }
+
+    /// <summary>
+    /// A single field assignment used in Fields.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class TemplateFieldAssignment
+    {
+        /// <summary>
+        /// The name of an existing field definition to assign to the template. Required.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldName", Required = Newtonsoft.Json.Required.Always)]
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// Whether the field is required for entries assigned to this template specifically.<br/>
+        /// Distinct from the repository-level IsRequired on the field definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// The per-template description for this field assignment.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for partial-update of an existing template definition. Every property<br/>
+    /// is optional.<br/>
+    /// null = leave the property unchanged.<br/>
+    /// Empty string ("") on a string property = clear the value.<br/>
+    /// To clear an existing color, set ClearColor to true and leave Color null. Supplying both Color and ClearColor=true is rejected with 400.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateRequest
+    {
+        /// <summary>
+        /// The new name of the template. Must be unique within the repository.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The description of the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The new color for the template. Omit to leave unchanged.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public LFColor Color { get; set; }
+
+        /// <summary>
+        /// Set to true to clear the template's existing color. Mutually exclusive with Color.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("clearColor", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? ClearColor { get; set; }
+
+        /// <summary>
+        /// Whether the template is eligible for automatic assignment by Cloud auto-classification.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isAutoAssignable", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsAutoAssignable { get; set; }
+
+    }
+
+    /// <summary>
+    /// The number of entries that have a value assigned for a given field definition,<br/>
+    /// or that are currently assigned to a given template definition.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AssignedEntryCountResponse
+    {
+        /// <summary>
+        /// The count of entries currently using this field or template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("count", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int Count { get; set; }
+
+    }
+
+    /// <summary>
+    /// Response body for the extended-properties bag on a template definition. The bag is<br/>
+    /// opaque: keys are WebDAV-style identifiers used by admin tooling and migration<br/>
+    /// utilities; values are strings consumers interpret. The response may include<br/>
+    /// LFS-internal entries (e.g. RA-managed flags) alongside caller-set keys; callers<br/>
+    /// should treat unrecognized keys as read-only system data.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class TemplatePropertiesResponse
+    {
+        /// <summary>
+        /// The full set of extended properties currently set on the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("properties", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IDictionary<string, string> Properties { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for partially updating the extended-properties bag on a template<br/>
+    /// definition. Entries in Set are written (creating or overwriting).<br/>
+    /// Entries in Remove are deleted. Properties not mentioned in either<br/>
+    /// are left unchanged.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplatePropertiesRequest
+    {
+        /// <summary>
+        /// Properties to set. Keys absent here are not modified.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("set", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IDictionary<string, string> Set { get; set; }
+
+        /// <summary>
+        /// Property keys to remove. Keys not currently set are ignored.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("remove", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<string> Remove { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for adding an existing field definition to a template.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AddTemplateFieldRequest
+    {
+        /// <summary>
+        /// The name of an existing field definition to assign to the template. Required.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldName", Required = Newtonsoft.Json.Required.Always)]
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// The 1-based position at which to insert the field. Omit (or set null) to append<br/>
+        /// to the end of the template. Values less than 1 or greater than the current<br/>
+        /// field count + 1 are rejected with 400.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("position", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Position { get; set; }
+
+        /// <summary>
+        /// Whether the field is required for entries assigned to this template specifically.<br/>
+        /// Distinct from the repository-level IsRequired on the field definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// The per-template description for this field assignment. Distinct from the<br/>
+        /// field definition's repository-level description.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for updating per-template properties on a field assignment that is<br/>
+    /// already part of a template. Repository-level field-definition properties are<br/>
+    /// unaffected by this endpoint — those go through the FieldDefinitions admin endpoints.<br/>
+    /// null = leave the property unchanged.<br/>
+    /// Empty string ("") on LocalDescription clears the value.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateFieldPropertiesRequest
+    {
+        /// <summary>
+        /// Whether the field is required for entries assigned to this template specifically.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// The per-template description for this field assignment.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for moving an existing field within a template to a new position.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MoveTemplateFieldRequest
+    {
+        /// <summary>
+        /// The name of the field to move. Required. Must already be part of the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldName", Required = Newtonsoft.Json.Required.Always)]
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// The 1-based target position. Required. Values less than 1 or greater than the<br/>
+        /// current field count are rejected with 400.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("newPosition", Required = Newtonsoft.Json.Required.Always)]
+        public int NewPosition { get; set; }
 
     }
 

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -4289,9 +4289,7 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file == null)
-                            throw new ArgumentNullException("parameters.File");
-                        else
+                        if (file != null)
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -4307,9 +4305,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -4344,9 +4340,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file == null)
-                                    throw new ArgumentNullException("parameters.File");
-                                else
+                                if (file != null)
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -4362,9 +4356,7 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -6902,9 +6894,7 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (file == null)
-                            throw new ArgumentNullException("parameters.File");
-                        else
+                        if (file != null)
                         {
                                 var content_file_ = new StreamContent(file.Data);
                                 if (!string.IsNullOrEmpty(file.ContentType))
@@ -6912,17 +6902,13 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_file_, "file", file.FileName ?? "file");
                             }
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -6957,9 +6943,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (file == null)
-                                    throw new ArgumentNullException("parameters.File");
-                                else
+                                if (file != null)
                                 {
                                         var content_file_ = new StreamContent(file.Data);
                                         if (!string.IsNullOrEmpty(file.ContentType))
@@ -6967,17 +6951,13 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_file_, "file", file.FileName ?? "file");
                                     }
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -7805,17 +7785,13 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -7850,17 +7826,13 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -8068,17 +8040,13 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
                             }
 
-                        if (imageFiles == null)
-                            throw new ArgumentNullException("parameters.ImageFiles");
-                        else
+                        if (imageFiles != null)
                         {
                             foreach (var item_ in imageFiles)
                             {
@@ -8113,17 +8081,13 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");
                                     }
 
-                                if (imageFiles == null)
-                                    throw new ArgumentNullException("parameters.ImageFiles");
-                                else
+                                if (imageFiles != null)
                                 {
                                     foreach (var item_ in imageFiles)
                                     {
@@ -8521,9 +8485,7 @@ namespace Laserfiche.Repository.Api.Client
                         content_.Headers.Remove("Content-Type");
                         content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                        if (imageFile == null)
-                            throw new ArgumentNullException("parameters.ImageFile");
-                        else
+                        if (imageFile != null)
                         {
                                 var content_imageFile_ = new StreamContent(imageFile.Data);
                                 if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -8531,9 +8493,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                             }
 
-                        if (request == null)
-                            throw new ArgumentNullException("parameters.Request");
-                        else
+                        if (request != null)
                         {
                                 var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                 content_.Add(new StringContent(json_), "request");
@@ -8563,9 +8523,7 @@ namespace Laserfiche.Repository.Api.Client
                                 content_.Headers.Remove("Content-Type");
                                 content_.Headers.TryAddWithoutValidation("Content-Type", "multipart/form-data; boundary=" + boundary_);
 
-                                if (imageFile == null)
-                                    throw new ArgumentNullException("parameters.ImageFile");
-                                else
+                                if (imageFile != null)
                                 {
                                         var content_imageFile_ = new StreamContent(imageFile.Data);
                                         if (!string.IsNullOrEmpty(imageFile.ContentType))
@@ -8573,9 +8531,7 @@ namespace Laserfiche.Repository.Api.Client
                                         content_.Add(content_imageFile_, "imageFile", imageFile.FileName ?? "imageFile");
                                     }
 
-                                if (request == null)
-                                    throw new ArgumentNullException("parameters.Request");
-                                else
+                                if (request != null)
                                 {
                                         var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
                                         content_.Add(new StringContent(json_), "request");

--- a/tests/integration/Entries/LockDocumentTest.cs
+++ b/tests/integration/Entries/LockDocumentTest.cs
@@ -38,7 +38,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 RepositoryId = RepositoryId,
                 EntryId = createdEntryId,
-                Request = new LockDocumentRequest() { Comment = "client test lock", Extent = "All" }
+                Request = new LockDocumentRequest() { Comment = "client test lock", Extent = LockExtent.All }
             }).ConfigureAwait(false);
 
             Assert.IsNotNull(lockResult);

--- a/tests/integration/Entries/LockDocumentTest.cs
+++ b/tests/integration/Entries/LockDocumentTest.cs
@@ -46,6 +46,10 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.IsNotNull(lockResult.LockToken);
             Assert.AreEqual("client test lock", lockResult.Comment);
             Assert.AreEqual(createdEntryId, lockResult.EntryId);
+            // Round-trip the extent so a server-side regression that silently defaults the
+            // extent (or ignores the enum value) is caught. Locked in after Codex round-2
+            // flagged the original "no exception thrown" assertion as unfalsifiable.
+            Assert.AreEqual("All", lockResult.Extent);
 
             // Get lock info
             var lockInfo = await client.EntriesClient.GetDocumentLockInfoAsync(new GetDocumentLockInfoParameters()
@@ -57,6 +61,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             Assert.IsNotNull(lockInfo);
             Assert.IsTrue(lockInfo.IsActive);
             Assert.AreEqual(lockResult.LockToken, lockInfo.LockToken);
+            Assert.AreEqual("All", lockInfo.Extent);
 
             // Unlock
             await client.EntriesClient.UnlockDocumentAsync(new UnlockDocumentParameters()

--- a/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
+++ b/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
@@ -1,0 +1,399 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using Laserfiche.Api.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
+{
+    /// <summary>
+    /// Integration tests for the template-definition admin endpoints introduced by PRD 6.3.C:
+    /// Create / Update / Delete + GetAssignedEntryCount + Get/UpdateProperties +
+    /// AddField / UpdateFieldProperties / RemoveField / MoveField.
+    /// </summary>
+    [TestClass]
+    public class TemplateAdminTest : BaseTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+        }
+
+        private static string UniqueName(string prefix) =>
+            $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid().ToString("N").Substring(0, 6)}";
+
+        // The admin tests reuse existing repository field definitions rather than creating
+        // their own. 6.3.C is independent of 6.3.A so CreateFieldDefinition isn't on the
+        // base swagger; we pick from what dev-CA already has.
+        private async Task<string[]> PickExistingFieldNamesAsync(int count)
+        {
+            var fields = await client.FieldDefinitionsClient.ListFieldDefinitionsAsync(new ListFieldDefinitionsParameters
+            {
+                RepositoryId = RepositoryId,
+            }).ConfigureAwait(false);
+            var names = fields.Value?
+                .Where(f => !string.IsNullOrEmpty(f.Name))
+                .Select(f => f.Name)
+                .Take(count)
+                .ToArray() ?? Array.Empty<string>();
+            Assert.IsTrue(names.Length >= count, $"Need at least {count} existing field definition(s) in dev-CA repository; found {names.Length}.");
+            return names;
+        }
+
+        private async Task SafeDeleteTemplateAsync(int templateId)
+        {
+            if (templateId <= 0) return;
+            try
+            {
+                await client.TemplateDefinitionsClient.DeleteTemplateAsync(new DeleteTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = templateId,
+                }).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Swallow cleanup failures so an earlier assertion isn't masked.
+            }
+        }
+
+        [TestMethod]
+        public async Task CreateUpdateDelete_Template_Lifecycle()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                // Create
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest
+                    {
+                        Name = templateName,
+                        Description = "Created from .NET client integration test",
+                        IsAutoAssignable = false,
+                        Color = new LFColor { A = 255, R = 100, G = 50, B = 25 },
+                    }
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(created);
+                Assert.IsTrue(created.Id > 0);
+                Assert.AreEqual(templateName, created.Name);
+                Assert.AreEqual("Created from .NET client integration test", created.Description);
+                Assert.IsFalse(created.IsAutoAssignable);
+                Assert.IsNotNull(created.Color);
+                Assert.AreEqual((byte)100, created.Color.R);
+                createdId = created.Id;
+
+                // Update — rename + flip IsAutoAssignable
+                string renamed = UniqueName("client_test_tmpl_renamed");
+                var updated = await client.TemplateDefinitionsClient.UpdateTemplateAsync(new UpdateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplateRequest
+                    {
+                        Name = renamed,
+                        IsAutoAssignable = true,
+                    }
+                }).ConfigureAwait(false);
+                Assert.AreEqual(renamed, updated.Name);
+                Assert.IsTrue(updated.IsAutoAssignable);
+
+                // Independent GET to confirm persistence
+                var readBack = await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(renamed, readBack.Name);
+                Assert.IsTrue(readBack.IsAutoAssignable);
+
+                // Delete
+                await client.TemplateDefinitionsClient.DeleteTemplateAsync(new DeleteTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                createdId = 0;
+
+                // 404 after delete
+                await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                {
+                    await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        TemplateId = createdId == 0 ? int.MaxValue - 1 : createdId,
+                    }).ConfigureAwait(false);
+                });
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task UpdateTemplate_ClearColor_SetsColorToNull()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest
+                    {
+                        Name = templateName,
+                        Color = new LFColor { A = 255, R = 30, G = 60, B = 90 },
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+                Assert.IsNotNull(created.Color);
+
+                await client.TemplateDefinitionsClient.UpdateTemplateAsync(new UpdateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplateRequest { ClearColor = true }
+                }).ConfigureAwait(false);
+
+                var readBack = await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsNull(readBack.Color, "Color should be cleared after ClearColor=true");
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task AddRemoveMoveField_Lifecycle()
+        {
+            var fieldNames = await PickExistingFieldNamesAsync(3);
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest { Name = templateName }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+                Assert.AreEqual(0, created.FieldCount);
+
+                // Add three fields
+                foreach (var name in fieldNames)
+                {
+                    await client.TemplateDefinitionsClient.AddTemplateFieldAsync(new AddTemplateFieldParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        TemplateId = createdId,
+                        Request = new AddTemplateFieldRequest { FieldName = name }
+                    }).ConfigureAwait(false);
+                }
+
+                // Read back: 3 fields, in addition order
+                var fieldsAfterAdd = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(fieldsAfterAdd.Value);
+                Assert.AreEqual(3, fieldsAfterAdd.Value.Count);
+                CollectionAssert.AreEqual(fieldNames, fieldsAfterAdd.Value.Select(f => f.Name).ToArray());
+
+                // Move first field to position 3
+                await client.TemplateDefinitionsClient.MoveTemplateFieldAsync(new MoveTemplateFieldParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new MoveTemplateFieldRequest { FieldName = fieldNames[0], NewPosition = 3 }
+                }).ConfigureAwait(false);
+
+                var fieldsAfterMove = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(3, fieldsAfterMove.Value.Count);
+                Assert.AreEqual(fieldNames[0], fieldsAfterMove.Value[2].Name, "Moved field should now be at position 3");
+
+                // Remove middle field
+                await client.TemplateDefinitionsClient.RemoveTemplateFieldAsync(new RemoveTemplateFieldParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    FieldName = fieldNames[1],
+                }).ConfigureAwait(false);
+
+                var fieldsAfterRemove = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(2, fieldsAfterRemove.Value.Count);
+                Assert.IsFalse(fieldsAfterRemove.Value.Any(f => f.Name == fieldNames[1]));
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task UpdateTemplateFieldProperties_IsRequired_RoundTrip()
+        {
+            // Note: LocalDescription is intentionally not exercised here. The
+            // underlying RA `SetFieldLocalDescription` requires LFS ≥ 12.0.2,
+            // which dev-CA runs older than at the time this test was authored.
+            // The contract still covers it on the API surface (controller test +
+            // server-side unit tests verify the LocalDescription branch).
+            var fieldNames = await PickExistingFieldNamesAsync(1);
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest
+                    {
+                        Name = templateName,
+                        Fields = new List<TemplateFieldAssignment>
+                        {
+                            new TemplateFieldAssignment { FieldName = fieldNames[0], IsRequired = false }
+                        }
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var before = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                var beforeField = before.Value.Single();
+                Assert.IsFalse(beforeField.IsRequired);
+
+                await client.TemplateDefinitionsClient.UpdateTemplateFieldPropertiesAsync(new UpdateTemplateFieldPropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    FieldName = fieldNames[0],
+                    Request = new UpdateTemplateFieldPropertiesRequest { IsRequired = true }
+                }).ConfigureAwait(false);
+
+                var after = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                var afterField = after.Value.Single();
+                Assert.IsTrue(afterField.IsRequired, "IsRequired should now be true");
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task Properties_RoundTrip()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest { Name = templateName }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                // Set initial keys
+                var first = await client.TemplateDefinitionsClient.UpdateTemplatePropertiesAsync(new UpdateTemplatePropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplatePropertiesRequest
+                    {
+                        Set = new Dictionary<string, string>
+                        {
+                            { "test.prop.one", "value-one" },
+                            { "test.prop.two", "value-two" },
+                        }
+                    }
+                }).ConfigureAwait(false);
+                Assert.IsTrue(first.Properties.ContainsKey("test.prop.one"));
+                Assert.AreEqual("value-one", first.Properties["test.prop.one"]);
+                Assert.AreEqual("value-two", first.Properties["test.prop.two"]);
+
+                // Independent GET
+                var readBack = await client.TemplateDefinitionsClient.GetTemplatePropertiesAsync(new GetTemplatePropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual("value-one", readBack.Properties["test.prop.one"]);
+
+                // Remove one, overwrite the other
+                var afterPatch = await client.TemplateDefinitionsClient.UpdateTemplatePropertiesAsync(new UpdateTemplatePropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplatePropertiesRequest
+                    {
+                        Set = new Dictionary<string, string> { { "test.prop.two", "value-two-updated" } },
+                        Remove = new List<string> { "test.prop.one" },
+                    }
+                }).ConfigureAwait(false);
+                Assert.IsFalse(afterPatch.Properties.ContainsKey("test.prop.one"), "test.prop.one should be removed");
+                Assert.AreEqual("value-two-updated", afterPatch.Properties["test.prop.two"]);
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetTemplateAssignedEntryCount_NewTemplate_ReturnsZero()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest { Name = templateName }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var count = await client.TemplateDefinitionsClient.GetTemplateAssignedEntryCountAsync(new GetTemplateAssignedEntryCountParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(count);
+                Assert.AreEqual(0, count.Count, "A fresh template should have zero assigned entries");
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+    }
+}

--- a/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
+++ b/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
@@ -114,6 +114,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                 Assert.IsTrue(readBack.IsAutoAssignable);
 
                 // Delete
+                int deletedId = createdId;
                 await client.TemplateDefinitionsClient.DeleteTemplateAsync(new DeleteTemplateParameters
                 {
                     RepositoryId = RepositoryId,
@@ -121,15 +122,16 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                 }).ConfigureAwait(false);
                 createdId = 0;
 
-                // 404 after delete
-                await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                // 404 after delete — verify the just-deleted template is actually gone.
+                var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
                 {
                     await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
                     {
                         RepositoryId = RepositoryId,
-                        TemplateId = createdId == 0 ? int.MaxValue - 1 : createdId,
+                        TemplateId = deletedId,
                     }).ConfigureAwait(false);
                 });
+                Assert.AreEqual(404, ex.StatusCode, $"Expected 404 from GET on deleted template id={deletedId}, got {ex.StatusCode}");
             }
             finally
             {

--- a/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
+++ b/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
@@ -55,9 +55,11 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                     TemplateId = templateId,
                 }).ConfigureAwait(false);
             }
-            catch
+            catch (Exception cleanupEx)
             {
-                // Swallow cleanup failures so an earlier assertion isn't masked.
+                // Don't fail the test on cleanup error (so an earlier assertion isn't masked),
+                // but log it so an orphan template doesn't accumulate silently across runs.
+                Console.WriteLine($"[TemplateAdminTest cleanup] DeleteTemplate id={templateId} failed: {cleanupEx.GetType().Name}: {cleanupEx.Message}");
             }
         }
 
@@ -122,7 +124,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                 }).ConfigureAwait(false);
                 createdId = 0;
 
-                // 404 after delete — verify the just-deleted template is actually gone.
+                // 404 after delete — verify the just-deleted template is actually gone, and
+                // that the response is a structured ProblemDetails (not a coarse network 404).
                 var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
                 {
                     await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
@@ -132,6 +135,8 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
                     }).ConfigureAwait(false);
                 });
                 Assert.AreEqual(404, ex.StatusCode, $"Expected 404 from GET on deleted template id={deletedId}, got {ex.StatusCode}");
+                Assert.IsNotNull(ex.ProblemDetails, "Expected a ProblemDetails body on the 404 response (not a coarse infrastructure 404).");
+                Assert.AreEqual(404, ex.ProblemDetails.Status, "ProblemDetails.Status should mirror the HTTP status.");
             }
             finally
             {


### PR DESCRIPTION
## Summary

Regenerated `RepositoryClients.cs` against the site-api-repository PRD 6.3.C swagger. Adds 10 new methods on `TemplateDefinitionsClient` plus parameter and request/response classes. Backward-compatible additions on existing template DTOs: `TemplateDefinition.isAutoAssignable`, `TemplateFieldDefinition.localDescription`.

Companion to **TFS PR #171930** (server) and **lf-api-js PR** (JS client, opened in parallel). Linked to TFS US #667475.

## New client methods (10)

`createTemplate`, `updateTemplate`, `deleteTemplate`, `getTemplateAssignedEntryCount`, `getTemplateProperties`, `updateTemplateProperties`, `addTemplateField`, `updateTemplateFieldProperties`, `removeTemplateField`, `moveTemplateField`.

## Integration tests

`tests/integration/TemplateDefinitions/TemplateAdminTest.cs` (6 tests, all green against dev-CA local server):
- Create / Update / Delete template lifecycle (with 404-after-delete + ProblemDetails assertion)
- UpdateTemplate ClearColor sets color to null
- Add / Move / Remove field lifecycle
- UpdateTemplateFieldProperties IsRequired round-trip
- Properties round-trip (set + remove)
- GetTemplateAssignedEntryCount on a fresh template

**LocalDescription branch intentionally not exercised** — RA `SetFieldLocalDescription` requires LFS ≥ 12.0.2; dev-CA runs older. Server unit tests cover the LocalDescription path.

## Other changes

- **`LockDocumentTest`**: server migrated `LockExtent` from string to enum (PR #197 cycle). One-line fix `Extent = LockExtent.All`; added round-trip assertion `Assert.AreEqual("All", lockResult.Extent)` and same on `lockInfo.Extent` so the test is now falsifiable.
- **`generate-client/SKILL.md`**: regen invocation corrected to `-output_folder src/Clients` (was `-output_folder src` which silently bypassed `patch_optional_multipart.py` against the canonical file). Documented the trap inline.

## Pre-PR reviews

- Codex round 1: 3 findings actioned (patch_optional_multipart re-run, 404 fix, LockExtent build fix)
- Codex round 2 adversarial: 11 findings — 2 medium (skill doc) + 4 actionable lows landed in commit `3b806ff`; 4 cleared on probe; 1 coverage-gap (low) deferred as follow-up

## Commits

- `70b0683` Regen client + integration tests (PRD 6.3.C)
- `e640dc2` Fix LockDocumentTest after server migrated LockExtent string → enum
- `721cb9c` Codex round 1: patch_optional_multipart + 404 verification fix
- `3b806ff` Codex round 2: skill doc + test falsifiability

## Test plan

- [x] `dotnet build src/Laserfiche.Repository.Api.Client.csproj`
- [x] `dotnet test tests/integration/ --filter "FullyQualifiedName~TemplateAdminTest"`
- [x] `dotnet test tests/integration/ --filter "FullyQualifiedName~LockDocumentTest"`
- [ ] Cloud deploy of server PR #171930 → re-run full integration suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)