### PR TITLE
Regen V2 client for full deployed surface: 6.3.A/B/C + REQ-DOC-002 (consolidated)

### DIFF
--- a/generate-client/swagger.json
+++ b/generate-client/swagger.json
@@ -3,15 +3,12 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Laserfiche Repository API",
-    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>0.0.0.1</p>",
+    "description": "Welcome to the Laserfiche API Swagger Playground. You can try out any of our API calls against your live Laserfiche Cloud account. Visit the developer center for more details: <a href=\"https://developer.laserfiche.com\">https://developer.laserfiche.com</a><p>Visit the changelog for the list of changes: <a href=\"/repository/v2/changelog\">/repository/v2/changelog</a></p><p><strong>Build# : </strong>1780117020_c895177fae051f04a31fdc4435df804fd4b8cde9</p>",
     "version": "2"
   },
   "servers": [
     {
-      "url": "http://localhost:11211/repository"
-    },
-    {
-      "url": "https://localhost:11211/repository"
+      "url": "https://api.laserfiche.com/repository"
     }
   ],
   "paths": {
@@ -1533,8 +1530,8 @@
         "tags": [
           "FieldDefinitions"
         ],
-        "summary": "Gets the extended-properties bag for a field definition.",
-        "description": "- The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.\n- Required OAuth scope: repository.Read",
+        "summary": "Gets the custom-properties bag for a field definition.",
+        "description": "- Returns the custom-properties bag persisted on the field definition. The bag is an opaque application-defined string \u2192 string map scoped to the definition itself (not to a user), useful for attaching integration metadata or application-specific configuration that belongs with the field \u2014 for example to encode list-field display preferences such as sort order, or to record an external system's identifier for the field.\n- Keys are application-defined; recommend a namespace prefix (e.g. com.acme.workflow.stage, myapp.kind) to avoid collisions across applications.\n- The response may include entries written by other applications or by system-managed tooling. Callers should leave unrecognized keys untouched on subsequent UpdateFieldProperties calls \u2014 round-tripping them in set preserves them, including them in remove deletes them.\n- Required OAuth scope: repository.Read",
         "operationId": "GetFieldProperties",
         "parameters": [
           {
@@ -1646,8 +1643,8 @@
         "tags": [
           "FieldDefinitions"
         ],
-        "summary": "Partially updates the extended-properties bag for a field definition.",
-        "description": "- Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.\n- Empty set and empty remove is a no-op and returns the current bag.\n- Returns the full property bag after the change.\n- Required OAuth scope: repository.Write",
+        "summary": "Partially updates the custom-properties bag for a field definition.",
+        "description": "- Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.\n- Empty set and empty remove is a no-op and returns the current bag.\n- Returns the full custom-properties bag after the change.\n- The bag is application-defined; the API does not validate key semantics. Recommend namespaced keys (e.g. com.acme.invoice.region, myapp.kind) to avoid collisions.\n- Required OAuth scope: repository.Write",
         "operationId": "UpdateFieldProperties",
         "parameters": [
           {
@@ -1692,6 +1689,231 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/FieldPropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/Merge": {
+      "post": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Merges two or more field definitions into a new field definition.",
+        "description": "- Combines the values of the source fields into a new field. onConflict controls per-entry value conflicts: Fail (default) aborts on conflict, MakeMultivalue keeps all values, UseFirstField keeps the first and discards the rest.\n- UseFirstField is lossy and requires allowDataLoss = true; otherwise the request is rejected with 400.\n- removeFromTemplates (default false) also removes the source fields from any templates that contain them. The source field definitions themselves are preserved regardless \u2014 the merge creates a new field, it does not delete the originals. Callers that want the sources gone must call DeleteFieldDefinition on each after the merge succeeds.\n- autoRename (default false) asks the repository to auto-select a non-conflicting name on collision; whether the repository honors this for merges is version-dependent, so callers should pre-validate newFieldName and treat an \"already exists\" error as a genuine collision.\n- At least two source fields are required.\n- Required OAuth scope: repository.Write",
+        "operationId": "MergeFields",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The source field IDs (two or more), the new field name, and merge options.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MergeFieldsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully merged the source fields into the new field definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Field definition with specified id was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ChangeType": {
+      "post": {
+        "tags": [
+          "FieldDefinitions"
+        ],
+        "summary": "Changes the data type of an existing field definition.",
+        "description": "- Converts the field to newFieldType. The conversion can reset type-specific configuration (length, constraint, format), clear list items when leaving the List type, and clear a default value that cannot be reinterpreted in the new type. Entries already assigned the field may have their values dropped if the existing data cannot survive the new type's domain.\n- When the conversion would lose data, allowDataLoss = true is required; otherwise the request is rejected with 400. The server treats the conversion as lossy unless it is one of the explicit safe widenings (Date \u2192 DateTime, ShortInteger \u2192 LongInteger, ShortInteger \u2192 Number, LongInteger \u2192 Number) and clearing list items / resetting a constraint / dropping a default would not actually discard data. A field with assigned entries that is not undergoing one of the safe widenings is always treated as lossy.\n- Required OAuth scope: repository.Write",
+        "operationId": "ChangeFieldType",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "fieldId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the field definition to convert.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The target field type and the data-loss acknowledgement.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangeFieldTypeRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully changed the field definition's type.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FieldDefinition"
                 }
               }
             }
@@ -2779,7 +3001,7 @@
           "Entries"
         ],
         "summary": "Returns a single entry object.",
-        "description": "- Returns a single entry object.\n- Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.\n- If the entry is a subtype (Folder, Document, or Shortcut), the response will automatically include properties specific to that entry type. For example, Document entries include page-related properties such as the number of image pages and whether an electronic document is attached. Entries with an electronic document component include the electronic document size (in bytes). Folder entries include whether the folder is a record series. Shortcut entries include the target entry ID.\n- Allowed OData query options: Select.\n- When OData Select query option is used, 'entryType' is always included in the result.\n- Required OAuth scope: repository.Read",
+        "description": "- Returns a single entry object.\n- Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.\n- If the entry is a subtype (Folder, Document, or Shortcut), the response will automatically include properties specific to that entry type. For example, Document entries include page-related properties such as the number of image pages and whether an electronic document is attached. Entries with an electronic document component include the electronic document size (in bytes). Folder entries include whether the folder is a record series. Shortcut entries include the target entry ID.\n- Optionally pass 'includeChildInfo=true' on a folder to retrieve, on demand, a 'childInfo' object with whether the folder has immediate children, the total immediate-child count, and a per-type breakdown (folder/document/shortcut). Immediate children only \u2014 recursive subtree counts are deliberately not supported here (unbounded, DoS-prone on a public API). This is opt-in because it is comparatively expensive; lazy expansion is the recommended pattern for folder tree navigation.\n- Optionally pass 'includeTotalSize=true' on a document to retrieve 'totalDocumentSize' \u2014 the full stored size including rendered pages, OCR text, thumbnails, and attachments \u2014 in addition to the electronic-document size. Opt-in because it aggregates across all pages.\n- Allowed OData query options: Select.\n- When OData Select query option is used, 'entryType' is always included in the result.\n- Required OAuth scope: repository.Read",
         "operationId": "GetEntry",
         "parameters": [
           {
@@ -2804,6 +3026,24 @@
             "x-position": 2
           },
           {
+            "name": "includeChildInfo",
+            "in": "query",
+            "description": "Optional. When true and the entry is a folder, includes a childInfo object reporting whether the folder has immediate children, the total count, and a per-type breakdown (folderCount, documentCount, shortcutCount). Counts are for immediate children only \u2014 never recursive/whole-subtree (a recursive count is intentionally not offered here; it would be an unbounded, DoS-prone operation on a public API). Omitted by default because the calculation is comparatively expensive \u2014 for tree UIs prefer lazy expansion (load children on demand) over requesting this per node. Ignored for non-folder entries.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 3
+          },
+          {
+            "name": "includeTotalSize",
+            "in": "query",
+            "description": "Optional. When true and the entry is a document, includes totalDocumentSize \u2014 the document's full stored size (electronic document plus page image/text/locations/thumbnail data and attachments), as opposed to electronicDocumentSize which is just the source file. Omitted by default because it aggregates across all of the document's pages. Ignored for non-document entries.",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 4
+          },
+          {
             "name": "$select",
             "in": "query",
             "description": "Limits the properties returned in the result.",
@@ -2811,7 +3051,7 @@
               "type": "string",
               "nullable": true
             },
-            "x-position": 3
+            "x-position": 5
           }
         ],
         "responses": {
@@ -9802,6 +10042,111 @@
             }
           }
         }
+      },
+      "post": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Creates a new template definition in the repository.",
+        "description": "- Creates a new metadata template with the supplied scalar properties and (optionally) an initial set of field assignments.\n- Names must be unique within the repository; duplicate-name failures surface as 409 Conflict from the underlying repository server.\n- Initial fields are appended in array order; each may carry per-template isRequired and localDescription. The repository-level field-definition properties are unaffected.\n- If the scalar template is successfully created but a subsequent AddField mid-loop fails, the template is left in place with the partial field set \u2014 there is no implicit rollback. Callers should treat the failure as transactional only at the scalar level and clean up via DeleteTemplate if needed.\n- The template extended-properties bag (REQ-ADMIN-006B) cannot be set during create \u2014 follow up with PATCH /Properties.\n- Required OAuth scope: repository.Write",
+        "operationId": "CreateTemplate",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The template definition to create. Name is required.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateTemplateRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully created the template definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict. The request could not be completed due to the current state of the resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}": {
@@ -9899,6 +10244,238 @@
           },
           "404": {
             "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Updates properties of an existing template definition (partial update).",
+        "description": "- Partial-update merge semantics. null = leave unchanged; \"\" = clear a string property.\n- To clear an existing color, set clearColor to true and leave color null. Supplying both is rejected with 400.\n- Field membership is managed via the AddTemplateField / RemoveTemplateField / MoveTemplateField endpoints.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateTemplate",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template to update.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The properties to change. Only non-null properties are applied; null leaves the property unchanged.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTemplateRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the template definition.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplateDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict. The request could not be completed due to the current state of the resource.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Deletes a template definition from the repository.",
+        "description": "- Deletes the specified template definition. If the template is currently assigned to entries, the underlying repository server rejects the request and the response surfaces as 409 Conflict.\n- Required OAuth scope: repository.Write",
+        "operationId": "DeleteTemplate",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template to delete.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully deleted the template definition."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict. The request could not be completed due to the current state of the resource.",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -10280,6 +10857,801 @@
           }
         }
       }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/AssignedEntryCount": {
+      "get": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Returns the count of entries currently assigned to the specified template definition.",
+        "description": "- Useful for impact analysis before performing destructive operations on the template.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetTemplateAssignedEntryCount",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the assigned entry count for the template.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssignedEntryCountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Properties": {
+      "get": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Gets the custom-properties bag for a template definition.",
+        "description": "- Returns the custom-properties bag persisted on the template definition. The bag is an opaque application-defined string \u2192 string map scoped to the definition itself (not to a user), useful for attaching integration metadata or application-specific configuration that belongs with the template \u2014 for example to record an external system's identifier for the template, or to encode display preferences such as field ordering hints.\n- Keys are application-defined; recommend a namespace prefix (e.g. com.acme.workflow.stage, myapp.template.category) to avoid collisions across applications.\n- The response may include entries written by other applications or by system-managed tooling. Callers should leave unrecognized keys untouched on subsequent UpdateTemplateProperties calls \u2014 round-tripping them in set preserves them, including them in remove deletes them.\n- Required OAuth scope: repository.Read",
+        "operationId": "GetTemplateProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "description": "Limits the properties returned in the result.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully returned the template extended-properties bag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplatePropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Partially updates the custom-properties bag for a template definition.",
+        "description": "- Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.\n- Empty set and empty remove is a no-op and returns the current bag.\n- Returns the full custom-properties bag after the change.\n- The bag is application-defined; the API does not validate key semantics. Recommend namespaced keys (e.g. com.acme.workflow.stage, myapp.template.category) to avoid collisions.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateTemplateProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTemplatePropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully updated the template extended-properties bag.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TemplatePropertiesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields": {
+      "post": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Adds a field to a template.",
+        "description": "- The field definition must already exist in the repository.\n- Per-template properties do not affect the repository-level field-definition properties.\n- Required OAuth scope: repository.Write",
+        "operationId": "AddTemplateField",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The field to add. fieldName is required. Optional position (1-based) inserts at that position; omit to append. Optional per-template isRequired and localDescription apply only to this template.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddTemplateFieldRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully added the field to the template."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/{fieldName}": {
+      "patch": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Updates per-template properties for a field assignment on a template.",
+        "description": "- Affects only the field's behavior on this specific template.\n- The repository-level field-definition properties are unchanged; use the FieldDefinitions admin endpoints for those.\n- Required OAuth scope: repository.Write",
+        "operationId": "UpdateTemplateFieldProperties",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "required": true,
+            "description": "The name of the field whose per-template properties to update. URL-decoded server-side.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 3
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The per-template properties to change. Null = leave unchanged; empty string clears localDescription.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateTemplateFieldPropertiesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 4
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully updated the per-template properties for the field assignment."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Removes a field from a template.",
+        "description": "- Field values already assigned to entries using this template are not affected \u2014 RA removes only the binding of the field to the template definition.\n- The field definition itself is not deleted; only the template assignment is removed.\n- Required OAuth scope: repository.Write",
+        "operationId": "RemoveTemplateField",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "fieldName",
+            "in": "path",
+            "required": true,
+            "description": "The name of the field to remove. URL-decoded server-side.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successfully removed the field from the template."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/Move": {
+      "post": {
+        "tags": [
+          "TemplateDefinitions"
+        ],
+        "summary": "Moves a field to a new position within a template.",
+        "description": "- The field must already be part of the template.\n- newPosition must be between 1 and the current field count, inclusive.\n- Required OAuth scope: repository.Write",
+        "operationId": "MoveTemplateField",
+        "parameters": [
+          {
+            "name": "repositoryId",
+            "in": "path",
+            "required": true,
+            "description": "The requested repository ID.",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "templateId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the template.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "description": "The field to move and the new 1-based position.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveTemplateFieldRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": "Successfully moved the field to the new position in the template."
+          },
+          "400": {
+            "description": "Invalid or bad request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Access token is invalid or expired.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access denied for the operation.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Template with requested ID was not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit is reached.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "An unexpected server-side error occurred.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -10302,7 +11674,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Attribute"
@@ -10408,7 +11779,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/AuditReason"
@@ -10754,7 +12124,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/FieldDefinition"
@@ -10873,7 +12242,7 @@
           },
           "properties": {
             "type": "object",
-            "description": "Initial extended properties (opaque WebDAV-keyed bag) to persist atomically with the field.\nUse the dedicated /FieldDefinitions/{id}/Properties endpoints to manage after creation.\nFor list fields, this is where the admin UI stores sort order, add-blank, add-Other,\ndisplay-as-dropdown, and similar UI-display options.",
+            "description": "Initial custom properties to persist atomically with the field. The bag is an opaque\napplication-defined string \u2192 string map scoped to the field definition; use it\nto attach integration metadata or application-specific configuration that should be\ncreated together with the field \u2014 for example to encode list-field display preferences\nsuch as sort order, or to record an external system's identifier for the field.\nKeys are application-defined; recommend namespaced keys (e.g. myapp.kind,\ncom.acme.field.source) to avoid collisions. Manage after creation via the\ndedicated /FieldDefinitions/{id}/Properties endpoints. Constraints: empty keys,\nnull values, and control characters are rejected with 400. Maximum 500 entries,\n256 chars per key, 1000 chars per value.",
             "nullable": true,
             "additionalProperties": {
               "type": "string"
@@ -11043,6 +12412,10 @@
             "type": "integer",
             "description": "The number of field definitions assigned to the template definition.",
             "format": "int32"
+          },
+          "isAutoAssignable": {
+            "type": "boolean",
+            "description": "Whether the template is eligible for automatic assignment by Cloud auto-classification."
           }
         }
       },
@@ -11075,24 +12448,24 @@
       },
       "AssignedEntryCountResponse": {
         "type": "object",
-        "description": "The number of entries that have a value assigned for a given field definition.",
+        "description": "The number of entries that have a value assigned for a given field definition,\nor that are currently assigned to a given template definition.",
         "additionalProperties": false,
         "properties": {
           "count": {
             "type": "integer",
-            "description": "The count of entries currently using this field.",
+            "description": "The count of entries currently using this field or template.",
             "format": "int32"
           }
         }
       },
       "FieldPropertiesResponse": {
         "type": "object",
-        "description": "Response body for the extended-properties bag on a field definition. The bag is opaque:\nkeys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field\nsort order, add-blank, add-Other, display-as), and values are strings the UI interprets.",
+        "description": "Response body for the custom-properties bag on a field definition. The bag is an opaque\napplication-defined string \u2192 string map persisted on the field definition itself\n(scoped to the definition, not to a user). Use it to attach integration metadata or\napplication-specific configuration that belongs with the field \u2014 for example to encode\nlist-field display preferences such as sort order, or to record an external system's\nidentifier for the field. Keys are application-defined; the API does not validate\nsemantic meaning. Recommend namespaced keys to avoid collisions, e.g.\ncom.acme.invoice.region or myapp.ingest.batch_id. The response may include\nentries written by other applications or by system-managed tooling; callers should\nleave unrecognized keys untouched on subsequent updates.",
         "additionalProperties": false,
         "properties": {
           "properties": {
             "type": "object",
-            "description": "The full set of extended properties currently set on the field.",
+            "description": "The full set of custom properties currently set on the field.",
             "nullable": true,
             "additionalProperties": {
               "type": "string"
@@ -11102,7 +12475,7 @@
       },
       "UpdateFieldPropertiesRequest": {
         "type": "object",
-        "description": "Request body for partially updating the extended-properties bag on a field definition.\nEntries in Set are written (creating or overwriting). Entries in Remove\nare deleted. Properties not mentioned in either are left unchanged.",
+        "description": "Request body for partially updating the custom-properties bag on a field definition.\nEntries in Set are written (creating or overwriting). Entries in Remove\nare deleted. Properties not mentioned in either are left unchanged. The bag is\napplication-defined; the API does not validate key semantics. Recommend namespaced keys\n(e.g. com.acme.invoice.region, myapp.kind) to avoid collisions.",
         "additionalProperties": false,
         "properties": {
           "set": {
@@ -11120,6 +12493,105 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "MergeFieldsRequest": {
+        "type": "object",
+        "description": "Request body for merging two or more field definitions into a new field definition.",
+        "additionalProperties": false,
+        "required": [
+          "sourceFieldIds",
+          "newFieldName"
+        ],
+        "properties": {
+          "sourceFieldIds": {
+            "type": "array",
+            "description": "The IDs of the field definitions to merge. At least two are required. Their values are\ncombined into a new field; see onConflict for how per-entry value conflicts are resolved.\nThe source field definitions are preserved by this operation \u2014 only their per-entry values\nare migrated to the new merged field. Use DeleteFieldDefinition on each source after\nthe merge if the originals are no longer needed.",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "newFieldName": {
+            "type": "string",
+            "description": "The name of the new merged field definition. Required. Must be unique within the repository\nunless autoRename is set."
+          },
+          "onConflict": {
+            "description": "How to resolve per-entry value conflicts across the source fields. Defaults to Fail\n(abort on conflict \u2014 nothing is discarded). UseFirstField discards conflicting values\nand therefore requires allowDataLoss = true.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldMergeConflictStrategy"
+              }
+            ]
+          },
+          "removeFromTemplates": {
+            "type": "boolean",
+            "description": "When true, removes the source fields from every template that contains them as part of the\nmerge. Defaults to false. This is a destructive side effect on template definitions; opt in explicitly."
+          },
+          "autoRename": {
+            "type": "boolean",
+            "description": "When true, requests that the repository auto-select a non-conflicting name if\nnewFieldName collides with an existing field. Defaults to false. Whether the\nrepository actually rewrites the name on collision is repository-version-dependent;\ncallers should not rely on it. The safe pattern is to ensure newFieldName is unique\nbefore calling, and to treat an \"already exists\" error response as a genuine collision."
+          },
+          "allowDataLoss": {
+            "type": "boolean",
+            "description": "Acknowledges that the requested merge will lose data and authorizes it to proceed. Required\n(must be true) only when the merge is lossy \u2014 i.e. onConflict = UseFirstField, which\ndiscards conflicting values. When the merge is lossless (Fail or MakeMultivalue)\nthis flag is ignored. A lossy merge without this flag returns 400 (data_loss_expected)."
+          }
+        }
+      },
+      "FieldMergeConflictStrategy": {
+        "type": "string",
+        "description": "Strategy for resolving per-entry value conflicts when merging multiple field definitions\ninto one. Applies when entries carry differing values across the source fields.",
+        "x-enum-names": [
+          "Fail",
+          "MakeMultivalue",
+          "UseFirstField"
+        ],
+        "x-enum-varnames": [
+          "Fail",
+          "MakeMultivalue",
+          "UseFirstField"
+        ],
+        "x-enumNames": [
+          "Fail",
+          "MakeMultivalue",
+          "UseFirstField"
+        ],
+        "x-enum-descriptions": [
+          null,
+          null,
+          null
+        ],
+        "x-enumDescriptions": [
+          null,
+          null,
+          null
+        ],
+        "enum": [
+          "Fail",
+          "MakeMultivalue",
+          "UseFirstField"
+        ]
+      },
+      "ChangeFieldTypeRequest": {
+        "type": "object",
+        "description": "Request body for changing the data type of an existing field definition.",
+        "additionalProperties": false,
+        "required": [
+          "newFieldType"
+        ],
+        "properties": {
+          "newFieldType": {
+            "description": "The target field type. Required. Changing type can reset type-specific configuration\n(length, constraint, format), clear list items when leaving the List type, and clear a\ndefault value that cannot be reinterpreted in the new type.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/FieldType"
+              }
+            ]
+          },
+          "allowDataLoss": {
+            "type": "boolean",
+            "description": "Acknowledges that the requested conversion will lose data and authorizes it to proceed.\nRequired (must be true) when any of the following hold: leaving the List type\n(clears list items); the field has a non-empty constraint, a defaultValue,\nor any assigned entries, AND the conversion is not one of the explicit safe widenings\n(Date \u2192 DateTime, ShortInteger \u2192 LongInteger, ShortInteger \u2192 Number,\nLongInteger \u2192 Number). A lossy conversion without this flag returns 400\n(data_loss_expected). Lossless conversions ignore this flag."
           }
         }
       },
@@ -11141,7 +12613,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/LinkDefinition"
@@ -12037,6 +13508,12 @@
                 "description": "The size of the electronic document attached to the represented document, if there is one, in bytes.",
                 "format": "int64"
               },
+              "totalDocumentSize": {
+                "type": "integer",
+                "description": "The total size in bytes of the document's stored components \u2014 electronic document plus\nimage/text/locations/thumbnail page data and attachments \u2014 as opposed to\nElectronicDocumentSize, which is just the source file. Present only when\nrequested via the includeTotalSize query parameter; otherwise null. Opt-in because\nit aggregates across all of the document's pages.",
+                "format": "int64",
+                "nullable": true
+              },
               "extension": {
                 "type": "string",
                 "description": "The extension for the document.",
@@ -12148,10 +13625,50 @@
               "isUnderRecordSeries": {
                 "type": "boolean",
                 "description": "A boolean indicating if the folder that this instance represents is known to directly or indirectly under a record series in the repository."
+              },
+              "childInfo": {
+                "description": "Opt-in introspection about the folder's immediate children (total + per-type counts).\nPresent only when includeChildInfo=true is supplied; otherwise null.",
+                "nullable": true,
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChildInfo"
+                  }
+                ]
               }
             }
           }
         ]
+      },
+      "ChildInfo": {
+        "type": "object",
+        "description": "Opt-in introspection about a folder's immediate children \u2014 a total count plus a per-type\nbreakdown. Returned only when explicitly requested via includeChildInfo=true, because\nthe underlying repository calculation is comparatively expensive. Counts are for immediate\nchildren only (never recursive/whole-subtree). For folder tree UIs, prefer optimistic lazy\nexpansion (load children on demand) over requesting this for every node.",
+        "additionalProperties": false,
+        "properties": {
+          "hasChildren": {
+            "type": "boolean",
+            "description": "Whether the folder has at least one immediate child of any type."
+          },
+          "childCount": {
+            "type": "integer",
+            "description": "Total number of immediate children across all entry types.",
+            "format": "int64"
+          },
+          "folderCount": {
+            "type": "integer",
+            "description": "Number of immediate child folders.",
+            "format": "int32"
+          },
+          "documentCount": {
+            "type": "integer",
+            "description": "Number of immediate child documents.",
+            "format": "int32"
+          },
+          "shortcutCount": {
+            "type": "integer",
+            "description": "Number of immediate child shortcuts.",
+            "format": "int32"
+          }
+        }
       },
       "ImportEntryRequest": {
         "type": "object",
@@ -12212,7 +13729,6 @@
         "properties": {
           "value": {
             "type": "string",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true
           }
         }
@@ -12330,7 +13846,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Entry"
@@ -12356,7 +13871,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Field"
@@ -12397,7 +13911,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Tag"
@@ -12517,7 +14030,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Link"
@@ -12898,7 +14410,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/PageInfoResponse"
@@ -13170,7 +14681,6 @@
         "properties": {
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/Repository"
@@ -13280,7 +14790,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/SearchContextHit"
@@ -13517,7 +15026,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TagDefinition"
@@ -13572,7 +15080,6 @@
         "properties": {
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TaskProgress"
@@ -13756,7 +15263,6 @@
         "properties": {
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/CancelTaskResult"
@@ -13806,7 +15312,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateDefinition"
@@ -13832,7 +15337,6 @@
           },
           "value": {
             "type": "array",
-            "description": "Gets or sets the OData response content in the \"value\".",
             "nullable": true,
             "items": {
               "$ref": "#/components/schemas/TemplateFieldDefinition"
@@ -13868,6 +15372,11 @@
                 "type": "string",
                 "description": "The name of field group.",
                 "nullable": true
+              },
+              "localDescription": {
+                "type": "string",
+                "description": "The per-template description for this field assignment. Distinct from the field\ndefinition's repository-level description; set via AddTemplateField /\nUpdateTemplateFieldProperties.",
+                "nullable": true
               }
             }
           }
@@ -13888,6 +15397,212 @@
             }
           }
         }
+      },
+      "CreateTemplateRequest": {
+        "type": "object",
+        "description": "Request body for creating a new template definition. Name is required; all other\nproperties are optional and fall back to repository defaults when omitted.",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the template. Required. Must be unique within the repository."
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the template.",
+            "nullable": true
+          },
+          "color": {
+            "description": "The color assigned to the template. Omit (or set null) for no color.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LFColor"
+              }
+            ]
+          },
+          "isAutoAssignable": {
+            "type": "boolean",
+            "description": "Whether the template is eligible for automatic assignment by Cloud auto-classification.\nDefaults to false when omitted.",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "description": "Optional initial field assignments. Order is preserved (each entry is appended\nin array order; the resulting position is 1-based). Each entry may carry the\nper-template isRequired and localDescription properties.\nNote: extended properties (the WebDAV-keyed bag) cannot be set during create\nbecause RepositoryAccess does not expose an atomic create-with-properties path\nfor templates. To set initial properties, follow Create with a PATCH /Properties\ncall against the returned template ID.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/TemplateFieldAssignment"
+            }
+          }
+        }
+      },
+      "TemplateFieldAssignment": {
+        "type": "object",
+        "description": "A single field assignment used in Fields.",
+        "additionalProperties": false,
+        "required": [
+          "fieldName"
+        ],
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "The name of an existing field definition to assign to the template. Required."
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required for entries assigned to this template specifically.\nDistinct from the repository-level IsRequired on the field definition.",
+            "nullable": true
+          },
+          "localDescription": {
+            "type": "string",
+            "description": "The per-template description for this field assignment.",
+            "nullable": true
+          }
+        }
+      },
+      "UpdateTemplateRequest": {
+        "type": "object",
+        "description": "Request body for partial-update of an existing template definition. Every property\nis optional.\nnull = leave the property unchanged.\nEmpty string (\"\") on a string property = clear the value.\nTo clear an existing color, set ClearColor to true and leave Color null. Supplying both Color and ClearColor=true is rejected with 400.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The new name of the template. Must be unique within the repository.",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the template.",
+            "nullable": true
+          },
+          "color": {
+            "description": "The new color for the template. Omit to leave unchanged.",
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/LFColor"
+              }
+            ]
+          },
+          "clearColor": {
+            "type": "boolean",
+            "description": "Set to true to clear the template's existing color. Mutually exclusive with Color.",
+            "nullable": true
+          },
+          "isAutoAssignable": {
+            "type": "boolean",
+            "description": "Whether the template is eligible for automatic assignment by Cloud auto-classification.",
+            "nullable": true
+          }
+        }
+      },
+      "TemplatePropertiesResponse": {
+        "type": "object",
+        "description": "Response body for the custom-properties bag on a template definition. The bag is an\nopaque application-defined string \u2192 string map persisted on the template\ndefinition itself (scoped to the definition, not to a user). Use it to attach\nintegration metadata or application-specific configuration that belongs with the\ntemplate \u2014 for example to record an external system's identifier for the template,\nor to encode display preferences such as field ordering hints. Keys are\napplication-defined; the API does not validate semantic meaning. Recommend\nnamespaced keys to avoid collisions, e.g. com.acme.workflow.stage or\nmyapp.template.category. The response may include entries written by other\napplications or by system-managed tooling; callers should leave unrecognized keys\nuntouched on subsequent updates.",
+        "additionalProperties": false,
+        "properties": {
+          "properties": {
+            "type": "object",
+            "description": "The full set of custom properties currently set on the template.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UpdateTemplatePropertiesRequest": {
+        "type": "object",
+        "description": "Request body for partially updating the custom-properties bag on a template definition.\nEntries in Set are written (creating or overwriting). Entries in\nRemove are deleted. Properties not mentioned in either are left unchanged.\nThe bag is application-defined; the API does not validate key semantics. Recommend\nnamespaced keys (e.g. com.acme.workflow.stage, myapp.template.category)\nto avoid collisions.",
+        "additionalProperties": false,
+        "properties": {
+          "set": {
+            "type": "object",
+            "description": "Properties to set. Keys absent here are not modified.",
+            "nullable": true,
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "remove": {
+            "type": "array",
+            "description": "Property keys to remove. Keys not currently set are ignored.",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "AddTemplateFieldRequest": {
+        "type": "object",
+        "description": "Request body for adding an existing field definition to a template.",
+        "additionalProperties": false,
+        "required": [
+          "fieldName"
+        ],
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "The name of an existing field definition to assign to the template. Required."
+          },
+          "position": {
+            "type": "integer",
+            "description": "The 1-based position at which to insert the field. Omit (or set null) to append\nto the end of the template. Values less than 1 or greater than the current\nfield count + 1 are rejected with 400.",
+            "format": "int32",
+            "nullable": true
+          },
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required for entries assigned to this template specifically.\nDistinct from the repository-level IsRequired on the field definition.",
+            "nullable": true
+          },
+          "localDescription": {
+            "type": "string",
+            "description": "The per-template description for this field assignment. Distinct from the\nfield definition's repository-level description.",
+            "nullable": true
+          }
+        }
+      },
+      "UpdateTemplateFieldPropertiesRequest": {
+        "type": "object",
+        "description": "Request body for updating per-template properties on a field assignment that is\nalready part of a template. Repository-level field-definition properties are\nunaffected by this endpoint \u2014 those go through the FieldDefinitions admin endpoints.\nnull = leave the property unchanged.\nEmpty string (\"\") on LocalDescription clears the value.",
+        "additionalProperties": false,
+        "properties": {
+          "isRequired": {
+            "type": "boolean",
+            "description": "Whether the field is required for entries assigned to this template specifically.",
+            "nullable": true
+          },
+          "localDescription": {
+            "type": "string",
+            "description": "The per-template description for this field assignment.",
+            "nullable": true
+          }
+        }
+      },
+      "MoveTemplateFieldRequest": {
+        "type": "object",
+        "description": "Request body for moving an existing field within a template to a new position.",
+        "additionalProperties": false,
+        "required": [
+          "fieldName",
+          "newPosition"
+        ],
+        "properties": {
+          "fieldName": {
+            "type": "string",
+            "description": "The name of the field to move. Required. Must already be part of the template."
+          },
+          "newPosition": {
+            "type": "integer",
+            "description": "The 1-based target position. Required. Values less than 1 or greater than the\ncurrent field count are rejected with 400.",
+            "format": "int32"
+          }
+        }
       }
     },
     "securitySchemes": {
@@ -13898,11 +15613,11 @@
       },
       "OAuth2 Authorization Code Flow": {
         "type": "oauth2",
-        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>http://localhost:11211/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
+        "description": "<p>Note: Please enter below the clientId/clientSecret of a registered web application, or the clientId of a SPA. For SPA, the clientSecret field must be left empty. The app, either a web application or SPA, must have the following uri defined as its redirect uri.</p><p>https://api.laserfiche.com/repository/swagger/oauth2-redirect.html</p><p>For more information, see <a href=\"https://developer.laserfiche.com/guides/guide_authenticating-to-the-swagger-playground.html\" target=\"_blank\">this page</a></p>",
         "flows": {
           "authorizationCode": {
-            "authorizationUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Authorize",
-            "tokenUrl": "https://signin.a.clouddev.laserfiche.ca/oauth/Token",
+            "authorizationUrl": "https://signin.laserfiche.com/oauth/Authorize",
+            "tokenUrl": "https://signin.laserfiche.com/oauth/Token",
             "scopes": {
               "repository.Read": "Allows the app to read the content of Laserfiche repositories on behalf of the signed-in user.",
               "repository.Write": "Allows the app to modify the content of Laserfiche repositories on behalf of the signed-in user."

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -1151,10 +1151,12 @@ namespace Laserfiche.Repository.Api.Client
         Task<AssignedEntryCountResponse> GetFieldAssignedEntryCountAsync(GetFieldAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Gets the extended-properties bag for a field definition.
+        /// Gets the custom-properties bag for a field definition.
         /// </summary>
         /// <remarks>
-        /// - The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.<br/>
+        /// - Returns the custom-properties bag persisted on the field definition. The bag is an opaque application-defined string → string map scoped to the definition itself (not to a user), useful for attaching integration metadata or application-specific configuration that belongs with the field — for example to encode list-field display preferences such as sort order, or to record an external system's identifier for the field.<br/>
+        /// - Keys are application-defined; recommend a namespace prefix (e.g. com.acme.workflow.stage, myapp.kind) to avoid collisions across applications.<br/>
+        /// - The response may include entries written by other applications or by system-managed tooling. Callers should leave unrecognized keys untouched on subsequent UpdateFieldProperties calls — round-tripping them in set preserves them, including them in remove deletes them.<br/>
         /// - Required OAuth scope: repository.Read
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -1164,12 +1166,13 @@ namespace Laserfiche.Repository.Api.Client
         Task<FieldPropertiesResponse> GetFieldPropertiesAsync(GetFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Partially updates the extended-properties bag for a field definition.
+        /// Partially updates the custom-properties bag for a field definition.
         /// </summary>
         /// <remarks>
         /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
         /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
-        /// - Returns the full property bag after the change.<br/>
+        /// - Returns the full custom-properties bag after the change.<br/>
+        /// - The bag is application-defined; the API does not validate key semantics. Recommend namespaced keys (e.g. com.acme.invoice.region, myapp.kind) to avoid collisions.<br/>
         /// - Required OAuth scope: repository.Write
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -1177,6 +1180,37 @@ namespace Laserfiche.Repository.Api.Client
         /// <returns>Successfully updated the extended properties for the field definition.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task<FieldPropertiesResponse> UpdateFieldPropertiesAsync(UpdateFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Merges two or more field definitions into a new field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Combines the values of the source fields into a new field. onConflict controls per-entry value conflicts: Fail (default) aborts on conflict, MakeMultivalue keeps all values, UseFirstField keeps the first and discards the rest.<br/>
+        /// - UseFirstField is lossy and requires allowDataLoss = true; otherwise the request is rejected with 400.<br/>
+        /// - removeFromTemplates (default false) also removes the source fields from any templates that contain them. The source field definitions themselves are preserved regardless — the merge creates a new field, it does not delete the originals. Callers that want the sources gone must call DeleteFieldDefinition on each after the merge succeeds.<br/>
+        /// - autoRename (default false) asks the repository to auto-select a non-conflicting name on collision; whether the repository honors this for merges is version-dependent, so callers should pre-validate newFieldName and treat an "already exists" error as a genuine collision.<br/>
+        /// - At least two source fields are required.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully merged the source fields into the new field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<FieldDefinition> MergeFieldsAsync(MergeFieldsParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Changes the data type of an existing field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Converts the field to newFieldType. The conversion can reset type-specific configuration (length, constraint, format), clear list items when leaving the List type, and clear a default value that cannot be reinterpreted in the new type. Entries already assigned the field may have their values dropped if the existing data cannot survive the new type's domain.<br/>
+        /// - When the conversion would lose data, allowDataLoss = true is required; otherwise the request is rejected with 400. The server treats the conversion as lossy unless it is one of the explicit safe widenings (Date → DateTime, ShortInteger → LongInteger, ShortInteger → Number, LongInteger → Number) and clearing list items / resetting a constraint / dropping a default would not actually discard data. A field with assigned entries that is not undergoing one of the safe widenings is always treated as lossy.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully changed the field definition's type.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<FieldDefinition> ChangeFieldTypeAsync(ChangeFieldTypeParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
     }
 
@@ -2693,10 +2727,12 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         /// <summary>
-        /// Gets the extended-properties bag for a field definition.
+        /// Gets the custom-properties bag for a field definition.
         /// </summary>
         /// <remarks>
-        /// - The bag is opaque: keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.<br/>
+        /// - Returns the custom-properties bag persisted on the field definition. The bag is an opaque application-defined string → string map scoped to the definition itself (not to a user), useful for attaching integration metadata or application-specific configuration that belongs with the field — for example to encode list-field display preferences such as sort order, or to record an external system's identifier for the field.<br/>
+        /// - Keys are application-defined; recommend a namespace prefix (e.g. com.acme.workflow.stage, myapp.kind) to avoid collisions across applications.<br/>
+        /// - The response may include entries written by other applications or by system-managed tooling. Callers should leave unrecognized keys untouched on subsequent UpdateFieldProperties calls — round-tripping them in set preserves them, including them in remove deletes them.<br/>
         /// - Required OAuth scope: repository.Read
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -2856,12 +2892,13 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         /// <summary>
-        /// Partially updates the extended-properties bag for a field definition.
+        /// Partially updates the custom-properties bag for a field definition.
         /// </summary>
         /// <remarks>
         /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
         /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
-        /// - Returns the full property bag after the change.<br/>
+        /// - Returns the full custom-properties bag after the change.<br/>
+        /// - The bag is application-defined; the API does not validate key semantics. Recommend namespaced keys (e.g. com.acme.invoice.region, myapp.kind) to avoid collisions.<br/>
         /// - Required OAuth scope: repository.Write
         /// </remarks>
         /// <param name="parameters">Parameters for the request.</param>
@@ -2942,6 +2979,333 @@ namespace Laserfiche.Repository.Api.Client
                 if (status_ == 200)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<FieldPropertiesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Merges two or more field definitions into a new field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Combines the values of the source fields into a new field. onConflict controls per-entry value conflicts: Fail (default) aborts on conflict, MakeMultivalue keeps all values, UseFirstField keeps the first and discards the rest.<br/>
+        /// - UseFirstField is lossy and requires allowDataLoss = true; otherwise the request is rejected with 400.<br/>
+        /// - removeFromTemplates (default false) also removes the source fields from any templates that contain them. The source field definitions themselves are preserved regardless — the merge creates a new field, it does not delete the originals. Callers that want the sources gone must call DeleteFieldDefinition on each after the merge succeeds.<br/>
+        /// - autoRename (default false) asks the repository to auto-select a non-conflicting name on collision; whether the repository honors this for merges is version-dependent, so callers should pre-validate newFieldName and treat an "already exists" error as a genuine collision.<br/>
+        /// - At least two source fields are required.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully merged the source fields into the new field definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<FieldDefinition> MergeFieldsAsync(MergeFieldsParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/Merge"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/Merge");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await MergeFieldsSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<FieldDefinition> MergeFieldsSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<FieldDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Changes the data type of an existing field definition.
+        /// </summary>
+        /// <remarks>
+        /// - Converts the field to newFieldType. The conversion can reset type-specific configuration (length, constraint, format), clear list items when leaving the List type, and clear a default value that cannot be reinterpreted in the new type. Entries already assigned the field may have their values dropped if the existing data cannot survive the new type's domain.<br/>
+        /// - When the conversion would lose data, allowDataLoss = true is required; otherwise the request is rejected with 400. The server treats the conversion as lossy unless it is one of the explicit safe widenings (Date → DateTime, ShortInteger → LongInteger, ShortInteger → Number, LongInteger → Number) and clearing list items / resetting a constraint / dropping a default would not actually discard data. A field with assigned entries that is not undergoing one of the safe widenings is always treated as lossy.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully changed the field definition's type.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<FieldDefinition> ChangeFieldTypeAsync(ChangeFieldTypeParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var fieldId = parameters.FieldId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (fieldId == null)
+                throw new ArgumentNullException("parameters.FieldId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ChangeType"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/FieldDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/ChangeType");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await ChangeFieldTypeSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<FieldDefinition> ChangeFieldTypeSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<FieldDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
                     if (objectResponse_.Object == null)
                     {
                         throw ApiExceptionExtensions.Create(status_, headers_, null);
@@ -3413,6 +3777,47 @@ namespace Laserfiche.Repository.Api.Client
         /// Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.
         /// </summary>
         public UpdateFieldPropertiesRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.MergeFieldsAsync(MergeFieldsParameters, CancellationToken)">MergeFields</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MergeFieldsParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The source field IDs (two or more), the new field name, and merge options.
+        /// </summary>
+        public MergeFieldsRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="IFieldDefinitionsClient.ChangeFieldTypeAsync(ChangeFieldTypeParameters, CancellationToken)">ChangeFieldType</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ChangeFieldTypeParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the field definition to convert.
+        /// </summary>
+        public int FieldId { get; set; }
+
+        /// <summary>
+        /// The target field type and the data-loss acknowledgement.
+        /// </summary>
+        public ChangeFieldTypeRequest Request { get; set; }
 
     }
 
@@ -4099,6 +4504,8 @@ namespace Laserfiche.Repository.Api.Client
         /// - Returns a single entry object.<br/>
         /// - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.<br/>
         /// - If the entry is a subtype (Folder, Document, or Shortcut), the response will automatically include properties specific to that entry type. For example, Document entries include page-related properties such as the number of image pages and whether an electronic document is attached. Entries with an electronic document component include the electronic document size (in bytes). Folder entries include whether the folder is a record series. Shortcut entries include the target entry ID.<br/>
+        /// - Optionally pass 'includeChildInfo=true' on a folder to retrieve, on demand, a 'childInfo' object with whether the folder has immediate children, the total immediate-child count, and a per-type breakdown (folder/document/shortcut). Immediate children only — recursive subtree counts are deliberately not supported here (unbounded, DoS-prone on a public API). This is opt-in because it is comparatively expensive; lazy expansion is the recommended pattern for folder tree navigation.<br/>
+        /// - Optionally pass 'includeTotalSize=true' on a document to retrieve 'totalDocumentSize' — the full stored size including rendered pages, OCR text, thumbnails, and attachments — in addition to the electronic-document size. Opt-in because it aggregates across all pages.<br/>
         /// - Allowed OData query options: Select.<br/>
         /// - When OData Select query option is used, 'entryType' is always included in the result.<br/>
         /// - Required OAuth scope: repository.Read
@@ -5617,6 +6024,8 @@ namespace Laserfiche.Repository.Api.Client
         /// - Returns a single entry object.<br/>
         /// - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.<br/>
         /// - If the entry is a subtype (Folder, Document, or Shortcut), the response will automatically include properties specific to that entry type. For example, Document entries include page-related properties such as the number of image pages and whether an electronic document is attached. Entries with an electronic document component include the electronic document size (in bytes). Folder entries include whether the folder is a record series. Shortcut entries include the target entry ID.<br/>
+        /// - Optionally pass 'includeChildInfo=true' on a folder to retrieve, on demand, a 'childInfo' object with whether the folder has immediate children, the total immediate-child count, and a per-type breakdown (folder/document/shortcut). Immediate children only — recursive subtree counts are deliberately not supported here (unbounded, DoS-prone on a public API). This is opt-in because it is comparatively expensive; lazy expansion is the recommended pattern for folder tree navigation.<br/>
+        /// - Optionally pass 'includeTotalSize=true' on a document to retrieve 'totalDocumentSize' — the full stored size including rendered pages, OCR text, thumbnails, and attachments — in addition to the electronic-document size. Opt-in because it aggregates across all pages.<br/>
         /// - Allowed OData query options: Select.<br/>
         /// - When OData Select query option is used, 'entryType' is always included in the result.<br/>
         /// - Required OAuth scope: repository.Read
@@ -5632,6 +6041,8 @@ namespace Laserfiche.Repository.Api.Client
 
             var repositoryId = parameters.RepositoryId;
             var entryId = parameters.EntryId;
+            var includeChildInfo = parameters.IncludeChildInfo;
+            var includeTotalSize = parameters.IncludeTotalSize;
             var select = parameters.Select;
 
             if (repositoryId == null)
@@ -5647,6 +6058,14 @@ namespace Laserfiche.Repository.Api.Client
                     urlBuilder_.Append("/Entries/");
                     urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(entryId, CultureInfo.InvariantCulture)));
                     urlBuilder_.Append('?');
+                    if (includeChildInfo != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("includeChildInfo")).Append('=').Append(Uri.EscapeDataString(ConvertToString(includeChildInfo, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (includeTotalSize != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("includeTotalSize")).Append('=').Append(Uri.EscapeDataString(ConvertToString(includeTotalSize, CultureInfo.InvariantCulture))).Append('&');
+                    }
                     if (select != null)
                     {
                         urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
@@ -13614,6 +14033,16 @@ namespace Laserfiche.Repository.Api.Client
         public int EntryId { get; set; }
 
         /// <summary>
+        /// Optional. When true and the entry is a folder, includes a childInfo object reporting whether the folder has immediate children, the total count, and a per-type breakdown (folderCount, documentCount, shortcutCount). Counts are for immediate children only — never recursive/whole-subtree (a recursive count is intentionally not offered here; it would be an unbounded, DoS-prone operation on a public API). Omitted by default because the calculation is comparatively expensive — for tree UIs prefer lazy expansion (load children on demand) over requesting this per node. Ignored for non-folder entries.
+        /// </summary>
+        public bool? IncludeChildInfo { get; set; } = null;
+
+        /// <summary>
+        /// Optional. When true and the entry is a document, includes totalDocumentSize — the document's full stored size (electronic document plus page image/text/locations/thumbnail data and attachments), as opposed to electronicDocumentSize which is just the source file. Omitted by default because it aggregates across all of the document's pages. Ignored for non-document entries.
+        /// </summary>
+        public bool? IncludeTotalSize { get; set; } = null;
+
+        /// <summary>
         /// Limits the properties returned in the result.
         /// </summary>
         public string Select { get; set; } = null;
@@ -17698,6 +18127,23 @@ namespace Laserfiche.Repository.Api.Client
         Task<TemplateDefinitionCollectionResponse> ListTemplateDefinitionsAsync(ListTemplateDefinitionsParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Creates a new template definition in the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Creates a new metadata template with the supplied scalar properties and (optionally) an initial set of field assignments.<br/>
+        /// - Names must be unique within the repository; duplicate-name failures surface as 409 Conflict from the underlying repository server.<br/>
+        /// - Initial fields are appended in array order; each may carry per-template isRequired and localDescription. The repository-level field-definition properties are unaffected.<br/>
+        /// - If the scalar template is successfully created but a subsequent AddField mid-loop fails, the template is left in place with the partial field set — there is no implicit rollback. Callers should treat the failure as transactional only at the scalar level and clean up via DeleteTemplate if needed.<br/>
+        /// - The template extended-properties bag (REQ-ADMIN-006B) cannot be set during create — follow up with PATCH /Properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully created the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplateDefinition> CreateTemplateAsync(CreateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Returns a single template definition object.
         /// </summary>
         /// <remarks>
@@ -17711,6 +18157,34 @@ namespace Laserfiche.Repository.Api.Client
         /// <returns>Successfully found and returned specified template.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task<TemplateDefinition> GetTemplateDefinitionAsync(GetTemplateDefinitionParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Updates properties of an existing template definition (partial update).
+        /// </summary>
+        /// <remarks>
+        /// - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.<br/>
+        /// - To clear an existing color, set clearColor to true and leave color null. Supplying both is rejected with 400.<br/>
+        /// - Field membership is managed via the AddTemplateField / RemoveTemplateField / MoveTemplateField endpoints.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplateDefinition> UpdateTemplateAsync(UpdateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Deletes a template definition from the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Deletes the specified template definition. If the template is currently assigned to entries, the underlying repository server rejects the request and the response surfaces as 409 Conflict.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully deleted the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task DeleteTemplateAsync(DeleteTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Returns the field definitions assigned to a template definition (by template definition ID).
@@ -17741,6 +18215,106 @@ namespace Laserfiche.Repository.Api.Client
         /// <returns>Returned list of field definitions for specified template.</returns>
         /// <exception cref="ApiException">A server side error occurred.</exception>
         Task<TemplateFieldDefinitionCollectionResponse> ListTemplateFieldDefinitionsByTemplateNameAsync(ListTemplateFieldDefinitionsByTemplateNameParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Returns the count of entries currently assigned to the specified template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Useful for impact analysis before performing destructive operations on the template.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the assigned entry count for the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<AssignedEntryCountResponse> GetTemplateAssignedEntryCountAsync(GetTemplateAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Gets the custom-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Returns the custom-properties bag persisted on the template definition. The bag is an opaque application-defined string → string map scoped to the definition itself (not to a user), useful for attaching integration metadata or application-specific configuration that belongs with the template — for example to record an external system's identifier for the template, or to encode display preferences such as field ordering hints.<br/>
+        /// - Keys are application-defined; recommend a namespace prefix (e.g. com.acme.workflow.stage, myapp.template.category) to avoid collisions across applications.<br/>
+        /// - The response may include entries written by other applications or by system-managed tooling. Callers should leave unrecognized keys untouched on subsequent UpdateTemplateProperties calls — round-tripping them in set preserves them, including them in remove deletes them.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplatePropertiesResponse> GetTemplatePropertiesAsync(GetTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Partially updates the custom-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
+        /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
+        /// - Returns the full custom-properties bag after the change.<br/>
+        /// - The bag is application-defined; the API does not validate key semantics. Recommend namespaced keys (e.g. com.acme.workflow.stage, myapp.template.category) to avoid collisions.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task<TemplatePropertiesResponse> UpdateTemplatePropertiesAsync(UpdateTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Adds a field to a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field definition must already exist in the repository.<br/>
+        /// - Per-template properties do not affect the repository-level field-definition properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully added the field to the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task AddTemplateFieldAsync(AddTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Updates per-template properties for a field assignment on a template.
+        /// </summary>
+        /// <remarks>
+        /// - Affects only the field's behavior on this specific template.<br/>
+        /// - The repository-level field-definition properties are unchanged; use the FieldDefinitions admin endpoints for those.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the per-template properties for the field assignment.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task UpdateTemplateFieldPropertiesAsync(UpdateTemplateFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Removes a field from a template.
+        /// </summary>
+        /// <remarks>
+        /// - Field values already assigned to entries using this template are not affected — RA removes only the binding of the field to the template definition.<br/>
+        /// - The field definition itself is not deleted; only the template assignment is removed.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully removed the field from the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task RemoveTemplateFieldAsync(RemoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Moves a field to a new position within a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field must already be part of the template.<br/>
+        /// - newPosition must be between 1 and the current field count, inclusive.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully moved the field to the new position in the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        Task MoveTemplateFieldAsync(MoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken));
 
     }
 
@@ -17963,6 +18537,168 @@ namespace Laserfiche.Repository.Api.Client
         }
 
         /// <summary>
+        /// Creates a new template definition in the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Creates a new metadata template with the supplied scalar properties and (optionally) an initial set of field assignments.<br/>
+        /// - Names must be unique within the repository; duplicate-name failures surface as 409 Conflict from the underlying repository server.<br/>
+        /// - Initial fields are appended in array order; each may carry per-template isRequired and localDescription. The repository-level field-definition properties are unaffected.<br/>
+        /// - If the scalar template is successfully created but a subsequent AddField mid-loop fails, the template is left in place with the partial field set — there is no implicit rollback. Callers should treat the failure as transactional only at the scalar level and clean up via DeleteTemplate if needed.<br/>
+        /// - The template extended-properties bag (REQ-ADMIN-006B) cannot be set during create — follow up with PATCH /Properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully created the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplateDefinition> CreateTemplateAsync(CreateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await CreateTemplateSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplateDefinition> CreateTemplateSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplateDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 409)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Returns a single template definition object.
         /// </summary>
         /// <remarks>
@@ -18090,6 +18826,342 @@ namespace Laserfiche.Repository.Api.Client
                 }
                 else
                 if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Updates properties of an existing template definition (partial update).
+        /// </summary>
+        /// <remarks>
+        /// - Partial-update merge semantics. null = leave unchanged; "" = clear a string property.<br/>
+        /// - To clear an existing color, set clearColor to true and leave color null. Supplying both is rejected with 400.<br/>
+        /// - Field membership is managed via the AddTemplateField / RemoveTemplateField / MoveTemplateField endpoints.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplateDefinition> UpdateTemplateAsync(UpdateTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await UpdateTemplateSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplateDefinition> UpdateTemplateSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplateDefinition>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 409)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Deletes a template definition from the repository.
+        /// </summary>
+        /// <remarks>
+        /// - Deletes the specified template definition. If the template is currently assigned to entries, the underlying repository server rejects the request and the response surfaces as 409 Conflict.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully deleted the template definition.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task DeleteTemplateAsync(DeleteTemplateParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("DELETE");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await DeleteTemplateSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task DeleteTemplateSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 409)
                 {
                     var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
                     if (objectResponse_.Object == null)
@@ -18518,6 +19590,1147 @@ namespace Laserfiche.Repository.Api.Client
             }
         }
 
+        /// <summary>
+        /// Returns the count of entries currently assigned to the specified template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Useful for impact analysis before performing destructive operations on the template.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the assigned entry count for the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<AssignedEntryCountResponse> GetTemplateAssignedEntryCountAsync(GetTemplateAssignedEntryCountParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var select = parameters.Select;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/AssignedEntryCount"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/AssignedEntryCount");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetTemplateAssignedEntryCountSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<AssignedEntryCountResponse> GetTemplateAssignedEntryCountSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<AssignedEntryCountResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Gets the custom-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Returns the custom-properties bag persisted on the template definition. The bag is an opaque application-defined string → string map scoped to the definition itself (not to a user), useful for attaching integration metadata or application-specific configuration that belongs with the template — for example to record an external system's identifier for the template, or to encode display preferences such as field ordering hints.<br/>
+        /// - Keys are application-defined; recommend a namespace prefix (e.g. com.acme.workflow.stage, myapp.template.category) to avoid collisions across applications.<br/>
+        /// - The response may include entries written by other applications or by system-managed tooling. Callers should leave unrecognized keys untouched on subsequent UpdateTemplateProperties calls — round-tripping them in set preserves them, including them in remove deletes them.<br/>
+        /// - Required OAuth scope: repository.Read
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully returned the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplatePropertiesResponse> GetTemplatePropertiesAsync(GetTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var select = parameters.Select;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Properties"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Properties");
+                    urlBuilder_.Append('?');
+                    if (select != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("$select")).Append('=').Append(Uri.EscapeDataString(ConvertToString(select, CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("GET");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await GetTemplatePropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplatePropertiesResponse> GetTemplatePropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplatePropertiesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Partially updates the custom-properties bag for a template definition.
+        /// </summary>
+        /// <remarks>
+        /// - Entries in set are written (creating or overwriting). Entries in remove are deleted. Properties not mentioned in either are left unchanged.<br/>
+        /// - Empty set and empty remove is a no-op and returns the current bag.<br/>
+        /// - Returns the full custom-properties bag after the change.<br/>
+        /// - The bag is application-defined; the API does not validate key semantics. Recommend namespaced keys (e.g. com.acme.workflow.stage, myapp.template.category) to avoid collisions.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the template extended-properties bag.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task<TemplatePropertiesResponse> UpdateTemplatePropertiesAsync(UpdateTemplatePropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Properties"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Properties");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+                    request_.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+                    return await UpdateTemplatePropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task<TemplatePropertiesResponse> UpdateTemplatePropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 200)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<TemplatePropertiesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    return objectResponse_.Object;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Adds a field to a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field definition must already exist in the repository.<br/>
+        /// - Per-template properties do not affect the repository-level field-definition properties.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully added the field to the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task AddTemplateFieldAsync(AddTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await AddTemplateFieldSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task AddTemplateFieldSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Updates per-template properties for a field assignment on a template.
+        /// </summary>
+        /// <remarks>
+        /// - Affects only the field's behavior on this specific template.<br/>
+        /// - The repository-level field-definition properties are unchanged; use the FieldDefinitions admin endpoints for those.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully updated the per-template properties for the field assignment.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task UpdateTemplateFieldPropertiesAsync(UpdateTemplateFieldPropertiesParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var fieldName = parameters.FieldName;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (fieldName == null)
+                throw new ArgumentNullException("parameters.FieldName");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/{fieldName}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldName, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("PATCH");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await UpdateTemplateFieldPropertiesSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task UpdateTemplateFieldPropertiesSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Removes a field from a template.
+        /// </summary>
+        /// <remarks>
+        /// - Field values already assigned to entries using this template are not affected — RA removes only the binding of the field to the template definition.<br/>
+        /// - The field definition itself is not deleted; only the template assignment is removed.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully removed the field from the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task RemoveTemplateFieldAsync(RemoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var fieldName = parameters.FieldName;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (fieldName == null)
+                throw new ArgumentNullException("parameters.FieldName");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/{fieldName}"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(fieldName, CultureInfo.InvariantCulture)));
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    request_.Method = new HttpMethod("DELETE");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await RemoveTemplateFieldSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task RemoveTemplateFieldSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Moves a field to a new position within a template.
+        /// </summary>
+        /// <remarks>
+        /// - The field must already be part of the template.<br/>
+        /// - newPosition must be between 1 and the current field count, inclusive.<br/>
+        /// - Required OAuth scope: repository.Write
+        /// </remarks>
+        /// <param name="parameters">Parameters for the request.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <returns>Successfully moved the field to the new position in the template.</returns>
+        /// <exception cref="ApiException">A server side error occurred.</exception>
+        public virtual async Task MoveTemplateFieldAsync(MoveTemplateFieldParameters parameters, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (parameters == null)
+                throw new ArgumentNullException("parameters");
+
+            var repositoryId = parameters.RepositoryId;
+            var templateId = parameters.TemplateId;
+            var request = parameters.Request;
+
+            if (repositoryId == null)
+                throw new ArgumentNullException("parameters.RepositoryId");
+
+            if (templateId == null)
+                throw new ArgumentNullException("parameters.TemplateId");
+
+            if (request == null)
+                throw new ArgumentNullException("parameters.Request");
+
+            var urlBuilder_ = new StringBuilder();
+                    // Operation Path: "v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}/Fields/Move"
+                    urlBuilder_.Append("v2/Repositories/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(repositoryId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/TemplateDefinitions/");
+                    urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(templateId, CultureInfo.InvariantCulture)));
+                    urlBuilder_.Append("/Fields/Move");
+
+            var client_ = _httpClient;
+            bool[] disposeClient_ = new bool[]{ false };
+            try
+            {
+                using (var request_ = new HttpRequestMessage())
+                {
+                    var json_ = Newtonsoft.Json.JsonConvert.SerializeObject(request, _settings.Value);
+                    var content_ = new StringContent(json_);
+                    content_.Headers.ContentType = MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new HttpMethod("POST");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new Uri(url_, UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    await MoveTemplateFieldSendAsync(request_, client_, disposeClient_, cancellationToken);
+                    return;
+                }
+            }
+            finally
+            {
+                if (disposeClient_[0])
+                    client_.Dispose();
+            }
+        }
+
+        protected virtual async Task MoveTemplateFieldSendAsync(HttpRequestMessage request_, HttpClient client_, bool[] disposeClient_, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var response_ = await client_.SendAsync(request_, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            var disposeResponse_ = true;
+            try
+            {
+                var headers_ = Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                if (response_.Content != null && response_.Content.Headers != null)
+                {
+                    foreach (var item_ in response_.Content.Headers)
+                        headers_[item_.Key] = item_.Value;
+                }
+
+                ProcessResponse(client_, response_);
+
+                var status_ = (int)response_.StatusCode;
+                if (status_ == 204)
+                {
+                    return;
+                }
+                else
+                if (status_ == 400)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 401)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 403)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 404)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 429)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                if (status_ == 500)
+                {
+                    var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                    if (objectResponse_.Object == null)
+                    {
+                        throw ApiExceptionExtensions.Create(status_, headers_, null);
+                    }
+                    throw ApiExceptionExtensions.Create(status_, headers_, objectResponse_.Object, null);
+                }
+                else
+                {
+                    var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw ApiExceptionExtensions.Create(status_, headers_, responseData_, JsonSerializerSettings, null);
+                }
+            }
+            finally
+            {
+                if (disposeResponse_)
+                    response_.Dispose();
+            }
+        }
+
         protected struct ObjectResponseResult<T>
         {
             public ObjectResponseResult(T responseObject, string responseText)
@@ -18684,6 +20897,24 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.CreateTemplateAsync(CreateTemplateParameters, CancellationToken)">CreateTemplate</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CreateTemplateParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The template definition to create. Name is required.
+        /// </summary>
+        public CreateTemplateRequest Request { get; set; }
+
+    }
+
+    /// <summary>
     /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.GetTemplateDefinitionAsync(GetTemplateDefinitionParameters, CancellationToken)">GetTemplateDefinition</see>.
     /// </summary>
     [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -18708,6 +20939,47 @@ namespace Laserfiche.Repository.Api.Client
         /// Limits the properties returned in the result.
         /// </summary>
         public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.UpdateTemplateAsync(UpdateTemplateParameters, CancellationToken)">UpdateTemplate</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template to update.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The properties to change. Only non-null properties are applied; null leaves the property unchanged.
+        /// </summary>
+        public UpdateTemplateRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.DeleteTemplateAsync(DeleteTemplateParameters, CancellationToken)">DeleteTemplate</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class DeleteTemplateParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template to delete.
+        /// </summary>
+        public int TemplateId { get; set; }
 
     }
 
@@ -18818,6 +21090,172 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.GetTemplateAssignedEntryCountAsync(GetTemplateAssignedEntryCountParameters, CancellationToken)">GetTemplateAssignedEntryCount</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetTemplateAssignedEntryCountParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.GetTemplatePropertiesAsync(GetTemplatePropertiesParameters, CancellationToken)">GetTemplateProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class GetTemplatePropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// Limits the properties returned in the result.
+        /// </summary>
+        public string Select { get; set; } = null;
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.UpdateTemplatePropertiesAsync(UpdateTemplatePropertiesParameters, CancellationToken)">UpdateTemplateProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplatePropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// Set and/or remove entries on the property bag. Keys not mentioned are left unchanged.
+        /// </summary>
+        public UpdateTemplatePropertiesRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.AddTemplateFieldAsync(AddTemplateFieldParameters, CancellationToken)">AddTemplateField</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AddTemplateFieldParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The field to add. fieldName is required. Optional position (1-based) inserts at that position; omit to append. Optional per-template isRequired and localDescription apply only to this template.
+        /// </summary>
+        public AddTemplateFieldRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.UpdateTemplateFieldPropertiesAsync(UpdateTemplateFieldPropertiesParameters, CancellationToken)">UpdateTemplateFieldProperties</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateFieldPropertiesParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The name of the field whose per-template properties to update. URL-decoded server-side.
+        /// </summary>
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// The per-template properties to change. Null = leave unchanged; empty string clears localDescription.
+        /// </summary>
+        public UpdateTemplateFieldPropertiesRequest Request { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.RemoveTemplateFieldAsync(RemoveTemplateFieldParameters, CancellationToken)">RemoveTemplateField</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class RemoveTemplateFieldParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The name of the field to remove. URL-decoded server-side.
+        /// </summary>
+        public string FieldName { get; set; }
+
+    }
+
+    /// <summary>
+    /// Represents the request parameters for <see cref="ITemplateDefinitionsClient.MoveTemplateFieldAsync(MoveTemplateFieldParameters, CancellationToken)">MoveTemplateField</see>.
+    /// </summary>
+    [GeneratedCode("NSwag", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MoveTemplateFieldParameters
+    {
+        /// <summary>
+        /// The requested repository ID.
+        /// </summary>
+        public string RepositoryId { get; set; }
+
+        /// <summary>
+        /// The ID of the template.
+        /// </summary>
+        public int TemplateId { get; set; }
+
+        /// <summary>
+        /// The field to move and the new 1-based position.
+        /// </summary>
+        public MoveTemplateFieldRequest Request { get; set; }
+
+    }
+
+    /// <summary>
     /// Response containing a collection of Attribute.
     /// </summary>
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
@@ -18835,9 +21273,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<Attribute> Value { get; set; }
 
@@ -18881,9 +21316,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<AuditReason> Value { get; set; }
 
@@ -19161,9 +21593,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<FieldDefinition> Value { get; set; }
 
@@ -19289,10 +21718,16 @@ namespace Laserfiche.Repository.Api.Client
         public IList<string> ListValues { get; set; }
 
         /// <summary>
-        /// Initial extended properties (opaque WebDAV-keyed bag) to persist atomically with the field.<br/>
-        /// Use the dedicated /FieldDefinitions/{id}/Properties endpoints to manage after creation.<br/>
-        /// For list fields, this is where the admin UI stores sort order, add-blank, add-Other,<br/>
-        /// display-as-dropdown, and similar UI-display options.
+        /// Initial custom properties to persist atomically with the field. The bag is an opaque<br/>
+        /// application-defined string → string map scoped to the field definition; use it<br/>
+        /// to attach integration metadata or application-specific configuration that should be<br/>
+        /// created together with the field — for example to encode list-field display preferences<br/>
+        /// such as sort order, or to record an external system's identifier for the field.<br/>
+        /// Keys are application-defined; recommend namespaced keys (e.g. myapp.kind,<br/>
+        /// com.acme.field.source) to avoid collisions. Manage after creation via the<br/>
+        /// dedicated /FieldDefinitions/{id}/Properties endpoints. Constraints: empty keys,<br/>
+        /// null values, and control characters are rejected with 400. Maximum 500 entries,<br/>
+        /// 256 chars per key, 1000 chars per value.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("properties", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IDictionary<string, string> Properties { get; set; }
@@ -19480,6 +21915,12 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("fieldCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int FieldCount { get; set; }
 
+        /// <summary>
+        /// Whether the template is eligible for automatic assignment by Cloud auto-classification.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isAutoAssignable", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool IsAutoAssignable { get; set; }
+
     }
 
     /// <summary>
@@ -19515,13 +21956,14 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
-    /// The number of entries that have a value assigned for a given field definition.
+    /// The number of entries that have a value assigned for a given field definition,<br/>
+    /// or that are currently assigned to a given template definition.
     /// </summary>
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class AssignedEntryCountResponse
     {
         /// <summary>
-        /// The count of entries currently using this field.
+        /// The count of entries currently using this field or template.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("count", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Count { get; set; }
@@ -19529,15 +21971,22 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
-    /// Response body for the extended-properties bag on a field definition. The bag is opaque:<br/>
-    /// keys are WebDAV-style identifiers used by the Cloud admin UI (e.g. to encode list-field<br/>
-    /// sort order, add-blank, add-Other, display-as), and values are strings the UI interprets.
+    /// Response body for the custom-properties bag on a field definition. The bag is an opaque<br/>
+    /// application-defined string → string map persisted on the field definition itself<br/>
+    /// (scoped to the definition, not to a user). Use it to attach integration metadata or<br/>
+    /// application-specific configuration that belongs with the field — for example to encode<br/>
+    /// list-field display preferences such as sort order, or to record an external system's<br/>
+    /// identifier for the field. Keys are application-defined; the API does not validate<br/>
+    /// semantic meaning. Recommend namespaced keys to avoid collisions, e.g.<br/>
+    /// com.acme.invoice.region or myapp.ingest.batch_id. The response may include<br/>
+    /// entries written by other applications or by system-managed tooling; callers should<br/>
+    /// leave unrecognized keys untouched on subsequent updates.
     /// </summary>
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class FieldPropertiesResponse
     {
         /// <summary>
-        /// The full set of extended properties currently set on the field.
+        /// The full set of custom properties currently set on the field.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("properties", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IDictionary<string, string> Properties { get; set; }
@@ -19545,9 +21994,11 @@ namespace Laserfiche.Repository.Api.Client
     }
 
     /// <summary>
-    /// Request body for partially updating the extended-properties bag on a field definition.<br/>
+    /// Request body for partially updating the custom-properties bag on a field definition.<br/>
     /// Entries in Set are written (creating or overwriting). Entries in Remove<br/>
-    /// are deleted. Properties not mentioned in either are left unchanged.
+    /// are deleted. Properties not mentioned in either are left unchanged. The bag is<br/>
+    /// application-defined; the API does not validate key semantics. Recommend namespaced keys<br/>
+    /// (e.g. com.acme.invoice.region, myapp.kind) to avoid collisions.
     /// </summary>
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class UpdateFieldPropertiesRequest
@@ -19563,6 +22014,114 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("remove", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<string> Remove { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for merging two or more field definitions into a new field definition.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MergeFieldsRequest
+    {
+        /// <summary>
+        /// The IDs of the field definitions to merge. At least two are required. Their values are<br/>
+        /// combined into a new field; see onConflict for how per-entry value conflicts are resolved.<br/>
+        /// The source field definitions are preserved by this operation — only their per-entry values<br/>
+        /// are migrated to the new merged field. Use DeleteFieldDefinition on each source after<br/>
+        /// the merge if the originals are no longer needed.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("sourceFieldIds", Required = Newtonsoft.Json.Required.Always)]
+        public IList<int> SourceFieldIds { get; set; } = new List<int>();
+
+        /// <summary>
+        /// The name of the new merged field definition. Required. Must be unique within the repository<br/>
+        /// unless autoRename is set.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("newFieldName", Required = Newtonsoft.Json.Required.Always)]
+        public string NewFieldName { get; set; }
+
+        /// <summary>
+        /// How to resolve per-entry value conflicts across the source fields. Defaults to Fail<br/>
+        /// (abort on conflict — nothing is discarded). UseFirstField discards conflicting values<br/>
+        /// and therefore requires allowDataLoss = true.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("onConflict", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FieldMergeConflictStrategy OnConflict { get; set; }
+
+        /// <summary>
+        /// When true, removes the source fields from every template that contains them as part of the<br/>
+        /// merge. Defaults to false. This is a destructive side effect on template definitions; opt in explicitly.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("removeFromTemplates", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool RemoveFromTemplates { get; set; }
+
+        /// <summary>
+        /// When true, requests that the repository auto-select a non-conflicting name if<br/>
+        /// newFieldName collides with an existing field. Defaults to false. Whether the<br/>
+        /// repository actually rewrites the name on collision is repository-version-dependent;<br/>
+        /// callers should not rely on it. The safe pattern is to ensure newFieldName is unique<br/>
+        /// before calling, and to treat an "already exists" error response as a genuine collision.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("autoRename", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool AutoRename { get; set; }
+
+        /// <summary>
+        /// Acknowledges that the requested merge will lose data and authorizes it to proceed. Required<br/>
+        /// (must be true) only when the merge is lossy — i.e. onConflict = UseFirstField, which<br/>
+        /// discards conflicting values. When the merge is lossless (Fail or MakeMultivalue)<br/>
+        /// this flag is ignored. A lossy merge without this flag returns 400 (data_loss_expected).
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("allowDataLoss", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool AllowDataLoss { get; set; }
+
+    }
+
+    /// <summary>
+    /// Strategy for resolving per-entry value conflicts when merging multiple field definitions<br/>
+    /// into one. Applies when entries carry differing values across the source fields.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public enum FieldMergeConflictStrategy
+    {
+
+        [EnumMember(Value = @"Fail")]
+        Fail = 0,
+
+        [EnumMember(Value = @"MakeMultivalue")]
+        MakeMultivalue = 1,
+
+        [EnumMember(Value = @"UseFirstField")]
+        UseFirstField = 2,
+
+    }
+
+    /// <summary>
+    /// Request body for changing the data type of an existing field definition.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ChangeFieldTypeRequest
+    {
+        /// <summary>
+        /// The target field type. Required. Changing type can reset type-specific configuration<br/>
+        /// (length, constraint, format), clear list items when leaving the List type, and clear a<br/>
+        /// default value that cannot be reinterpreted in the new type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("newFieldType", Required = Newtonsoft.Json.Required.Always)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public FieldType NewFieldType { get; set; }
+
+        /// <summary>
+        /// Acknowledges that the requested conversion will lose data and authorizes it to proceed.<br/>
+        /// Required (must be true) when any of the following hold: leaving the List type<br/>
+        /// (clears list items); the field has a non-empty constraint, a defaultValue,<br/>
+        /// or any assigned entries, AND the conversion is not one of the explicit safe widenings<br/>
+        /// (Date → DateTime, ShortInteger → LongInteger, ShortInteger → Number,<br/>
+        /// LongInteger → Number). A lossy conversion without this flag returns 400<br/>
+        /// (data_loss_expected). Lossless conversions ignore this flag.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("allowDataLoss", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool AllowDataLoss { get; set; }
 
     }
 
@@ -19584,9 +22143,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<LinkDefinition> Value { get; set; }
 
@@ -20382,6 +22938,16 @@ namespace Laserfiche.Repository.Api.Client
         public long ElectronicDocumentSize { get; set; }
 
         /// <summary>
+        /// The total size in bytes of the document's stored components — electronic document plus<br/>
+        /// image/text/locations/thumbnail page data and attachments — as opposed to<br/>
+        /// ElectronicDocumentSize, which is just the source file. Present only when<br/>
+        /// requested via the includeTotalSize query parameter; otherwise null. Opt-in because<br/>
+        /// it aggregates across all of the document's pages.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("totalDocumentSize", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public long? TotalDocumentSize { get; set; }
+
+        /// <summary>
         /// The extension for the document.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("extension", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -20516,6 +23082,55 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("isUnderRecordSeries", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool IsUnderRecordSeries { get; set; }
 
+        /// <summary>
+        /// Opt-in introspection about the folder's immediate children (total + per-type counts).<br/>
+        /// Present only when includeChildInfo=true is supplied; otherwise null.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("childInfo", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public ChildInfo ChildInfo { get; set; }
+
+    }
+
+    /// <summary>
+    /// Opt-in introspection about a folder's immediate children — a total count plus a per-type<br/>
+    /// breakdown. Returned only when explicitly requested via includeChildInfo=true, because<br/>
+    /// the underlying repository calculation is comparatively expensive. Counts are for immediate<br/>
+    /// children only (never recursive/whole-subtree). For folder tree UIs, prefer optimistic lazy<br/>
+    /// expansion (load children on demand) over requesting this for every node.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class ChildInfo
+    {
+        /// <summary>
+        /// Whether the folder has at least one immediate child of any type.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("hasChildren", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool HasChildren { get; set; }
+
+        /// <summary>
+        /// Total number of immediate children across all entry types.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("childCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public long ChildCount { get; set; }
+
+        /// <summary>
+        /// Number of immediate child folders.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("folderCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int FolderCount { get; set; }
+
+        /// <summary>
+        /// Number of immediate child documents.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("documentCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int DocumentCount { get; set; }
+
+        /// <summary>
+        /// Number of immediate child shortcuts.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("shortcutCount", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int ShortcutCount { get; set; }
+
     }
 
     /// <summary>
@@ -20577,9 +23192,6 @@ namespace Laserfiche.Repository.Api.Client
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class ExportEntryResponse
     {
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Value { get; set; }
 
@@ -20688,9 +23300,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<Entry> Value { get; set; }
 
@@ -20714,9 +23323,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<Field> Value { get; set; }
 
@@ -20754,9 +23360,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<Tag> Value { get; set; }
 
@@ -20883,9 +23486,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<Link> Value { get; set; }
 
@@ -21250,9 +23850,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<PageInfoResponse> Value { get; set; }
 
@@ -21493,9 +24090,6 @@ namespace Laserfiche.Repository.Api.Client
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class RepositoryCollectionResponse
     {
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<Repository> Value { get; set; }
 
@@ -21587,9 +24181,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<SearchContextHit> Value { get; set; }
 
@@ -21783,9 +24374,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<TagDefinition> Value { get; set; }
 
@@ -21841,9 +24429,6 @@ namespace Laserfiche.Repository.Api.Client
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class TaskCollectionResponse
     {
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<TaskProgress> Value { get; set; }
 
@@ -21981,9 +24566,6 @@ namespace Laserfiche.Repository.Api.Client
     [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial class CancelTasksResponse
     {
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<CancelTaskResult> Value { get; set; }
 
@@ -22034,9 +24616,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<TemplateDefinition> Value { get; set; }
 
@@ -22060,9 +24639,6 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("@odata.count", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? OdataCount { get; set; }
 
-        /// <summary>
-        /// Gets or sets the OData response content in the "value".
-        /// </summary>
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<TemplateFieldDefinition> Value { get; set; }
 
@@ -22092,6 +24668,14 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("groupName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string GroupName { get; set; }
 
+        /// <summary>
+        /// The per-template description for this field assignment. Distinct from the field<br/>
+        /// definition's repository-level description; set via AddTemplateField /<br/>
+        /// UpdateTemplateFieldProperties.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
     }
 
     /// <summary>
@@ -22105,6 +24689,251 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("ancestors", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public IList<int> Ancestors { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for creating a new template definition. Name is required; all other<br/>
+    /// properties are optional and fall back to repository defaults when omitted.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class CreateTemplateRequest
+    {
+        /// <summary>
+        /// The name of the template. Required. Must be unique within the repository.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Always)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The description of the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The color assigned to the template. Omit (or set null) for no color.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public LFColor Color { get; set; }
+
+        /// <summary>
+        /// Whether the template is eligible for automatic assignment by Cloud auto-classification.<br/>
+        /// Defaults to false when omitted.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isAutoAssignable", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsAutoAssignable { get; set; }
+
+        /// <summary>
+        /// Optional initial field assignments. Order is preserved (each entry is appended<br/>
+        /// in array order; the resulting position is 1-based). Each entry may carry the<br/>
+        /// per-template isRequired and localDescription properties.<br/>
+        /// Note: extended properties (the WebDAV-keyed bag) cannot be set during create<br/>
+        /// because RepositoryAccess does not expose an atomic create-with-properties path<br/>
+        /// for templates. To set initial properties, follow Create with a PATCH /Properties<br/>
+        /// call against the returned template ID.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fields", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<TemplateFieldAssignment> Fields { get; set; }
+
+    }
+
+    /// <summary>
+    /// A single field assignment used in Fields.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class TemplateFieldAssignment
+    {
+        /// <summary>
+        /// The name of an existing field definition to assign to the template. Required.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldName", Required = Newtonsoft.Json.Required.Always)]
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// Whether the field is required for entries assigned to this template specifically.<br/>
+        /// Distinct from the repository-level IsRequired on the field definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// The per-template description for this field assignment.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for partial-update of an existing template definition. Every property<br/>
+    /// is optional.<br/>
+    /// null = leave the property unchanged.<br/>
+    /// Empty string ("") on a string property = clear the value.<br/>
+    /// To clear an existing color, set ClearColor to true and leave Color null. Supplying both Color and ClearColor=true is rejected with 400.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateRequest
+    {
+        /// <summary>
+        /// The new name of the template. Must be unique within the repository.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("name", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The description of the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The new color for the template. Omit to leave unchanged.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public LFColor Color { get; set; }
+
+        /// <summary>
+        /// Set to true to clear the template's existing color. Mutually exclusive with Color.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("clearColor", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? ClearColor { get; set; }
+
+        /// <summary>
+        /// Whether the template is eligible for automatic assignment by Cloud auto-classification.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isAutoAssignable", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsAutoAssignable { get; set; }
+
+    }
+
+    /// <summary>
+    /// Response body for the custom-properties bag on a template definition. The bag is an<br/>
+    /// opaque application-defined string → string map persisted on the template<br/>
+    /// definition itself (scoped to the definition, not to a user). Use it to attach<br/>
+    /// integration metadata or application-specific configuration that belongs with the<br/>
+    /// template — for example to record an external system's identifier for the template,<br/>
+    /// or to encode display preferences such as field ordering hints. Keys are<br/>
+    /// application-defined; the API does not validate semantic meaning. Recommend<br/>
+    /// namespaced keys to avoid collisions, e.g. com.acme.workflow.stage or<br/>
+    /// myapp.template.category. The response may include entries written by other<br/>
+    /// applications or by system-managed tooling; callers should leave unrecognized keys<br/>
+    /// untouched on subsequent updates.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class TemplatePropertiesResponse
+    {
+        /// <summary>
+        /// The full set of custom properties currently set on the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("properties", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IDictionary<string, string> Properties { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for partially updating the custom-properties bag on a template definition.<br/>
+    /// Entries in Set are written (creating or overwriting). Entries in<br/>
+    /// Remove are deleted. Properties not mentioned in either are left unchanged.<br/>
+    /// The bag is application-defined; the API does not validate key semantics. Recommend<br/>
+    /// namespaced keys (e.g. com.acme.workflow.stage, myapp.template.category)<br/>
+    /// to avoid collisions.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplatePropertiesRequest
+    {
+        /// <summary>
+        /// Properties to set. Keys absent here are not modified.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("set", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IDictionary<string, string> Set { get; set; }
+
+        /// <summary>
+        /// Property keys to remove. Keys not currently set are ignored.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("remove", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<string> Remove { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for adding an existing field definition to a template.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class AddTemplateFieldRequest
+    {
+        /// <summary>
+        /// The name of an existing field definition to assign to the template. Required.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldName", Required = Newtonsoft.Json.Required.Always)]
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// The 1-based position at which to insert the field. Omit (or set null) to append<br/>
+        /// to the end of the template. Values less than 1 or greater than the current<br/>
+        /// field count + 1 are rejected with 400.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("position", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public int? Position { get; set; }
+
+        /// <summary>
+        /// Whether the field is required for entries assigned to this template specifically.<br/>
+        /// Distinct from the repository-level IsRequired on the field definition.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// The per-template description for this field assignment. Distinct from the<br/>
+        /// field definition's repository-level description.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for updating per-template properties on a field assignment that is<br/>
+    /// already part of a template. Repository-level field-definition properties are<br/>
+    /// unaffected by this endpoint — those go through the FieldDefinitions admin endpoints.<br/>
+    /// null = leave the property unchanged.<br/>
+    /// Empty string ("") on LocalDescription clears the value.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class UpdateTemplateFieldPropertiesRequest
+    {
+        /// <summary>
+        /// Whether the field is required for entries assigned to this template specifically.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("isRequired", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool? IsRequired { get; set; }
+
+        /// <summary>
+        /// The per-template description for this field assignment.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("localDescription", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string LocalDescription { get; set; }
+
+    }
+
+    /// <summary>
+    /// Request body for moving an existing field within a template to a new position.
+    /// </summary>
+    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MoveTemplateFieldRequest
+    {
+        /// <summary>
+        /// The name of the field to move. Required. Must already be part of the template.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("fieldName", Required = Newtonsoft.Json.Required.Always)]
+        public string FieldName { get; set; }
+
+        /// <summary>
+        /// The 1-based target position. Required. Values less than 1 or greater than the<br/>
+        /// current field count are rejected with 400.
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("newPosition", Required = Newtonsoft.Json.Required.Always)]
+        public int NewPosition { get; set; }
 
     }
 

--- a/tests/integration/Entries/EntryIntrospectionTest.cs
+++ b/tests/integration/Entries/EntryIntrospectionTest.cs
@@ -1,0 +1,130 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
+{
+    /// <summary>
+    /// REQ-DOC-002 opt-in introspection on Get Entry: the folder childInfo facet and the
+    /// document totalDocumentSize. Both are single-GET-only and must be omitted unless requested.
+    /// </summary>
+    [TestClass]
+    public class EntryIntrospectionTest : BaseTest
+    {
+        private const int RootFolderId = 1;
+        Entry importedEntry;
+        Stream fileStream;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+            importedEntry = null;
+            fileStream = null;
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            fileStream?.Dispose();
+            if (importedEntry != null)
+            {
+                await DeleteEntry(importedEntry.Id).ConfigureAwait(false);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetEntry_IncludeChildInfo_RootFolder_ReportsTotalAndPerTypeCounts()
+        {
+            var entry = await client.EntriesClient.GetEntryAsync(new GetEntryParameters()
+            {
+                RepositoryId = RepositoryId,
+                EntryId = RootFolderId,
+                IncludeChildInfo = true
+            }).ConfigureAwait(false);
+
+            var folder = entry as Folder;
+            Assert.IsNotNull(folder, "Root entry should be a folder");
+            Assert.IsNotNull(folder.ChildInfo, "childInfo should be populated when requested");
+            // Single object: a total plus the per-type breakdown.
+            Assert.AreEqual(
+                (long)folder.ChildInfo.FolderCount + folder.ChildInfo.DocumentCount + folder.ChildInfo.ShortcutCount,
+                folder.ChildInfo.ChildCount,
+                "childCount should equal the sum of the per-type counts");
+            Assert.AreEqual(folder.ChildInfo.ChildCount > 0, folder.ChildInfo.HasChildren,
+                "hasChildren must be consistent with childCount");
+            // The repository root reliably contains at least one child in our test environments.
+            Assert.IsTrue(folder.ChildInfo.ChildCount > 0, "Root folder should report a positive child count");
+        }
+
+        [TestMethod]
+        public async Task GetEntry_NoChildInfo_OmitsChildInfo()
+        {
+            var entry = await client.EntriesClient.GetEntryAsync(new GetEntryParameters()
+            {
+                RepositoryId = RepositoryId,
+                EntryId = RootFolderId
+            }).ConfigureAwait(false);
+
+            var folder = entry as Folder;
+            Assert.IsNotNull(folder);
+            Assert.IsNull(folder.ChildInfo, "childInfo must be omitted (not null) when not requested");
+        }
+
+        [TestMethod]
+        public async Task GetEntry_IncludeTotalSize_Document_ReturnsTotalAtLeastEdocSize()
+        {
+            importedEntry = await ImportTestDocument().ConfigureAwait(false);
+
+            var entry = await client.EntriesClient.GetEntryAsync(new GetEntryParameters()
+            {
+                RepositoryId = RepositoryId,
+                EntryId = importedEntry.Id,
+                IncludeTotalSize = true
+            }).ConfigureAwait(false);
+
+            var document = entry as Document;
+            Assert.IsNotNull(document, "Imported entry should be a document");
+            Assert.IsNotNull(document.TotalDocumentSize, "totalDocumentSize should be populated when requested");
+            // Total stored size = electronic document + page (image/text/locations/thumbnail) data +
+            // attachments. Pages render asynchronously after import (see server async page/OCR note),
+            // so for a freshly imported edoc-only document the total may equal the edoc size; the
+            // >= assertion is robust either way.
+            Assert.IsTrue(document.TotalDocumentSize.Value >= document.ElectronicDocumentSize,
+                $"totalDocumentSize ({document.TotalDocumentSize}) should be >= electronicDocumentSize ({document.ElectronicDocumentSize})");
+        }
+
+        [TestMethod]
+        public async Task GetEntry_Document_NoIncludeTotalSize_OmitsTotalSize()
+        {
+            importedEntry = await ImportTestDocument().ConfigureAwait(false);
+
+            var entry = await client.EntriesClient.GetEntryAsync(new GetEntryParameters()
+            {
+                RepositoryId = RepositoryId,
+                EntryId = importedEntry.Id
+            }).ConfigureAwait(false);
+
+            var document = entry as Document;
+            Assert.IsNotNull(document);
+            Assert.IsNull(document.TotalDocumentSize, "totalDocumentSize must be omitted when not requested");
+        }
+
+        private async Task<Entry> ImportTestDocument()
+        {
+            string fileLocation = TempPath + "test.pdf";
+            fileStream = File.OpenRead(fileLocation);
+            var file = new FileParameter(fileStream, "test.pdf", "application/pdf");
+            return await client.EntriesClient.ImportEntryAsync(new ImportEntryParameters()
+            {
+                RepositoryId = RepositoryId,
+                EntryId = RootFolderId,
+                File = file,
+                Request = new ImportEntryRequest() { Name = "IntegrationTest EntryIntrospection", AutoRename = true }
+            }).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/integration/FieldDefinitions/FieldMergeChangeTypeTest.cs
+++ b/tests/integration/FieldDefinitions/FieldMergeChangeTypeTest.cs
@@ -1,0 +1,567 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using Laserfiche.Api.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.FieldDefinitions
+{
+    /// <summary>
+    /// Integration tests for the field destructive-operation endpoints introduced by PRD 6.3.B:
+    /// POST /FieldDefinitions/Merge and POST /FieldDefinitions/{fieldId}/ChangeType.
+    /// Exercises both happy paths and the allowDataLoss gating.
+    /// </summary>
+    [TestClass]
+    public class FieldMergeChangeTypeTest : BaseTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+        }
+
+        private static string UniqueName(string prefix) =>
+            $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid().ToString("N").Substring(0, 6)}";
+
+        private async Task TryDeleteField(int fieldId)
+        {
+            if (fieldId <= 0) return;
+            try
+            {
+                await client.FieldDefinitionsClient.DeleteFieldDefinitionAsync(new DeleteFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = fieldId,
+                }).ConfigureAwait(false);
+            }
+            catch (ApiException ex) when (ex.StatusCode == 404)
+            {
+                // A parallel test or a manual repo edit could have removed the field already.
+            }
+        }
+
+        // Reads a field directly to assert that MergeFields preserved it. Any failure (including 404)
+        // surfaces as a test failure — MergeFields does not consume sources, so the GET must succeed.
+        private async Task AssertFieldExists(int fieldId, string expectedName)
+        {
+            var fetched = await client.FieldDefinitionsClient.GetFieldDefinitionAsync(new GetFieldDefinitionParameters
+            {
+                RepositoryId = RepositoryId,
+                FieldId = fieldId,
+            }).ConfigureAwait(false);
+            Assert.AreEqual(expectedName, fetched.Name);
+        }
+
+        private async Task<FieldDefinition> CreateStringField(string namePrefix, int length = 25)
+        {
+            return await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+            {
+                RepositoryId = RepositoryId,
+                Request = new CreateFieldDefinitionRequest
+                {
+                    Name = UniqueName(namePrefix),
+                    FieldType = FieldType.String,
+                    Length = length,
+                }
+            }).ConfigureAwait(false);
+        }
+
+        // ---------------- MergeFields ----------------
+
+        [TestMethod]
+        public async Task MergeFields_TwoStringFields_FailStrategy_HappyPath()
+        {
+            FieldDefinition src1 = null, src2 = null;
+            int mergedId = 0;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_src1");
+                src2 = await CreateStringField("client_test_merge_src2");
+
+                string newName = UniqueName("client_test_merge_dest");
+                var merged = await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new MergeFieldsRequest
+                    {
+                        SourceFieldIds = new List<int> { src1.Id, src2.Id },
+                        NewFieldName = newName,
+                        OnConflict = FieldMergeConflictStrategy.Fail,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(merged);
+                Assert.IsTrue(merged.Id > 0);
+                Assert.AreEqual(newName, merged.Name);
+                mergedId = merged.Id;
+
+                // Independent GET — confirm the new field is discoverable post-merge (defense against same-request masking).
+                var fetched = await client.FieldDefinitionsClient.GetFieldDefinitionAsync(new GetFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = mergedId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(newName, fetched.Name);
+
+                // Source field definitions are preserved by MergeFields — the operation creates a new field,
+                // it does not delete the originals. Confirms the documented lifecycle contract.
+                await AssertFieldExists(src1.Id, src1.Name);
+                await AssertFieldExists(src2.Id, src2.Name);
+            }
+            finally
+            {
+                await TryDeleteField(mergedId);
+                if (src1 != null) await TryDeleteField(src1.Id);
+                if (src2 != null) await TryDeleteField(src2.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task MergeFields_MakeMultivalueStrategy_HappyPath()
+        {
+            FieldDefinition src1 = null, src2 = null;
+            int mergedId = 0;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_mv_src1");
+                src2 = await CreateStringField("client_test_merge_mv_src2");
+
+                var merged = await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new MergeFieldsRequest
+                    {
+                        SourceFieldIds = new List<int> { src1.Id, src2.Id },
+                        NewFieldName = UniqueName("client_test_merge_mv_dest"),
+                        OnConflict = FieldMergeConflictStrategy.MakeMultivalue,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(merged);
+                Assert.IsTrue(merged.Id > 0);
+                mergedId = merged.Id;
+
+                await AssertFieldExists(src1.Id, src1.Name);
+                await AssertFieldExists(src2.Id, src2.Name);
+            }
+            finally
+            {
+                await TryDeleteField(mergedId);
+                if (src1 != null) await TryDeleteField(src1.Id);
+                if (src2 != null) await TryDeleteField(src2.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task MergeFields_OneSource_Throws400()
+        {
+            FieldDefinition src1 = null;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_lone_src");
+
+                var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                    await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        Request = new MergeFieldsRequest
+                        {
+                            SourceFieldIds = new List<int> { src1.Id },
+                            NewFieldName = UniqueName("client_test_merge_lone_dest"),
+                            OnConflict = FieldMergeConflictStrategy.Fail,
+                        },
+                    }).ConfigureAwait(false)).ConfigureAwait(false);
+
+                Assert.AreEqual(400, ex.StatusCode);
+            }
+            finally
+            {
+                if (src1 != null) await TryDeleteField(src1.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task MergeFields_DuplicateSourceIds_Throws400()
+        {
+            FieldDefinition src1 = null;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_dup_src");
+
+                var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                    await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        Request = new MergeFieldsRequest
+                        {
+                            SourceFieldIds = new List<int> { src1.Id, src1.Id },
+                            NewFieldName = UniqueName("client_test_merge_dup_dest"),
+                            OnConflict = FieldMergeConflictStrategy.Fail,
+                        },
+                    }).ConfigureAwait(false)).ConfigureAwait(false);
+
+                Assert.AreEqual(400, ex.StatusCode);
+            }
+            finally
+            {
+                if (src1 != null) await TryDeleteField(src1.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task MergeFields_UseFirstFieldWithoutAllowDataLoss_Throws400()
+        {
+            FieldDefinition src1 = null, src2 = null;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_uff_src1");
+                src2 = await CreateStringField("client_test_merge_uff_src2");
+
+                var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                    await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        Request = new MergeFieldsRequest
+                        {
+                            SourceFieldIds = new List<int> { src1.Id, src2.Id },
+                            NewFieldName = UniqueName("client_test_merge_uff_dest"),
+                            OnConflict = FieldMergeConflictStrategy.UseFirstField,
+                            AllowDataLoss = false,
+                        },
+                    }).ConfigureAwait(false)).ConfigureAwait(false);
+
+                Assert.AreEqual(400, ex.StatusCode);
+            }
+            finally
+            {
+                if (src1 != null) await TryDeleteField(src1.Id);
+                if (src2 != null) await TryDeleteField(src2.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task MergeFields_UseFirstFieldWithAllowDataLoss_Succeeds()
+        {
+            FieldDefinition src1 = null, src2 = null;
+            int mergedId = 0;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_uffok_src1");
+                src2 = await CreateStringField("client_test_merge_uffok_src2");
+
+                var merged = await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new MergeFieldsRequest
+                    {
+                        SourceFieldIds = new List<int> { src1.Id, src2.Id },
+                        NewFieldName = UniqueName("client_test_merge_uffok_dest"),
+                        OnConflict = FieldMergeConflictStrategy.UseFirstField,
+                        AllowDataLoss = true,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(merged);
+                Assert.IsTrue(merged.Id > 0);
+                mergedId = merged.Id;
+
+                await AssertFieldExists(src1.Id, src1.Name);
+                await AssertFieldExists(src2.Id, src2.Name);
+            }
+            finally
+            {
+                await TryDeleteField(mergedId);
+                if (src1 != null) await TryDeleteField(src1.Id);
+                if (src2 != null) await TryDeleteField(src2.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task MergeFields_RemoveFromTemplates_PassThroughSucceeds()
+        {
+            // V2 has no template CRUD, so the side effect on templates can't be observed end-to-end here.
+            // This test exercises the option pass-through: the request deserializes, the controller forwards
+            // removeFromTemplates=true to the connector, and the RA call (with no template references to clean
+            // up) returns success. Behavioral effect is covered by RA's MergeFieldsNoRemoveFromTemplate /
+            // MergeBasicWithMultivalue tests in RepositoryAccess.
+            FieldDefinition src1 = null, src2 = null;
+            int mergedId = 0;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_rft_src1");
+                src2 = await CreateStringField("client_test_merge_rft_src2");
+
+                var merged = await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new MergeFieldsRequest
+                    {
+                        SourceFieldIds = new List<int> { src1.Id, src2.Id },
+                        NewFieldName = UniqueName("client_test_merge_rft_dest"),
+                        OnConflict = FieldMergeConflictStrategy.Fail,
+                        RemoveFromTemplates = true,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.IsTrue(merged.Id > 0);
+                mergedId = merged.Id;
+
+                // The option doesn't affect source-field lifecycle — sources remain even when
+                // removeFromTemplates=true (which only affects template references).
+                await AssertFieldExists(src1.Id, src1.Name);
+                await AssertFieldExists(src2.Id, src2.Name);
+            }
+            finally
+            {
+                await TryDeleteField(mergedId);
+                if (src1 != null) await TryDeleteField(src1.Id);
+                if (src2 != null) await TryDeleteField(src2.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task MergeFields_AutoRename_PassThroughSucceeds()
+        {
+            // Pass-through coverage for the autoRename option: confirms the parameter deserializes and
+            // is forwarded through controller → connector → RA without faulting. The visible effect on
+            // collision is repository-version-dependent (LFS's merge endpoint does not always honor
+            // X-LF-Autorename the way Field.Create does), so this test exercises only the no-collision
+            // happy path. Tests that depend on the rename behavior live with RepositoryAccess.
+            FieldDefinition src1 = null, src2 = null;
+            int mergedId = 0;
+            try
+            {
+                src1 = await CreateStringField("client_test_merge_autorename_src1");
+                src2 = await CreateStringField("client_test_merge_autorename_src2");
+
+                string newName = UniqueName("client_test_merge_autorename_dest");
+                var merged = await client.FieldDefinitionsClient.MergeFieldsAsync(new MergeFieldsParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new MergeFieldsRequest
+                    {
+                        SourceFieldIds = new List<int> { src1.Id, src2.Id },
+                        NewFieldName = newName,
+                        OnConflict = FieldMergeConflictStrategy.Fail,
+                        AutoRename = true,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.IsTrue(merged.Id > 0);
+                mergedId = merged.Id;
+                // Without a collision, AutoRename has nothing to do — the requested name is honored.
+                Assert.AreEqual(newName, merged.Name);
+            }
+            finally
+            {
+                await TryDeleteField(mergedId);
+                if (src1 != null) await TryDeleteField(src1.Id);
+                if (src2 != null) await TryDeleteField(src2.Id);
+            }
+        }
+
+        // ---------------- ChangeFieldType ----------------
+
+        [TestMethod]
+        public async Task ChangeFieldType_LosslessStringToList_HappyPath()
+        {
+            // Brand-new String field with no constraint/default/entries → safe to widen the type domain.
+            FieldDefinition fld = null;
+            try
+            {
+                fld = await CreateStringField("client_test_change_lossless");
+
+                var changed = await client.FieldDefinitionsClient.ChangeFieldTypeAsync(new ChangeFieldTypeParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = fld.Id,
+                    Request = new ChangeFieldTypeRequest
+                    {
+                        NewFieldType = FieldType.List,
+                        AllowDataLoss = false,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(changed);
+                Assert.AreEqual(FieldType.List, changed.FieldType);
+
+                // Independent GET — confirms the ChangeType+Save reached storage (defense against missed Save).
+                var fetched = await client.FieldDefinitionsClient.GetFieldDefinitionAsync(new GetFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = fld.Id,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(FieldType.List, fetched.FieldType);
+            }
+            finally
+            {
+                if (fld != null) await TryDeleteField(fld.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task ChangeFieldType_SafeWidening_ShortToLong_Succeeds()
+        {
+            // ShortInteger→LongInteger is a same-family widening — all existing values fit, so it's lossless
+            // even with assigned entries. This test runs without assigned entries; the predicate path proven
+            // out is "no constraint, no default, no entries" — but proving the API accepts the widening here
+            // also documents the supported transition for callers.
+            FieldDefinition fld = null;
+            try
+            {
+                fld = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = UniqueName("client_test_change_widen"),
+                        FieldType = FieldType.ShortInteger,
+                    }
+                }).ConfigureAwait(false);
+
+                var changed = await client.FieldDefinitionsClient.ChangeFieldTypeAsync(new ChangeFieldTypeParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = fld.Id,
+                    Request = new ChangeFieldTypeRequest
+                    {
+                        NewFieldType = FieldType.LongInteger,
+                        AllowDataLoss = false,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.AreEqual(FieldType.LongInteger, changed.FieldType);
+            }
+            finally
+            {
+                if (fld != null) await TryDeleteField(fld.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task ChangeFieldType_LeavingListWithoutFlag_Throws400()
+        {
+            // Leaving the List type clears list items unconditionally → always lossy.
+            FieldDefinition fld = null;
+            try
+            {
+                fld = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = UniqueName("client_test_change_leave_list"),
+                        FieldType = FieldType.List,
+                        Length = 25,
+                        ListValues = new List<string> { "Red", "Blue" },
+                    }
+                }).ConfigureAwait(false);
+
+                var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                    await client.FieldDefinitionsClient.ChangeFieldTypeAsync(new ChangeFieldTypeParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = fld.Id,
+                        Request = new ChangeFieldTypeRequest
+                        {
+                            NewFieldType = FieldType.String,
+                            AllowDataLoss = false,
+                        },
+                    }).ConfigureAwait(false)).ConfigureAwait(false);
+
+                Assert.AreEqual(400, ex.StatusCode);
+            }
+            finally
+            {
+                if (fld != null) await TryDeleteField(fld.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task ChangeFieldType_LeavingListWithFlag_Succeeds()
+        {
+            FieldDefinition fld = null;
+            try
+            {
+                fld = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = UniqueName("client_test_change_leave_list_ok"),
+                        FieldType = FieldType.List,
+                        Length = 25,
+                        ListValues = new List<string> { "Red", "Blue" },
+                    }
+                }).ConfigureAwait(false);
+
+                var changed = await client.FieldDefinitionsClient.ChangeFieldTypeAsync(new ChangeFieldTypeParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = fld.Id,
+                    Request = new ChangeFieldTypeRequest
+                    {
+                        NewFieldType = FieldType.String,
+                        AllowDataLoss = true,
+                    },
+                }).ConfigureAwait(false);
+
+                Assert.AreEqual(FieldType.String, changed.FieldType);
+
+                // Independent GET — confirm the type change persisted to storage.
+                var fetched = await client.FieldDefinitionsClient.GetFieldDefinitionAsync(new GetFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    FieldId = fld.Id,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(FieldType.String, fetched.FieldType);
+            }
+            finally
+            {
+                if (fld != null) await TryDeleteField(fld.Id);
+            }
+        }
+
+        [TestMethod]
+        public async Task ChangeFieldType_ConstraintCrossFamilyWithoutFlag_Throws400()
+        {
+            // String field with a regex constraint converted to Number: the constraint can't survive a
+            // cross-family change → IsLossyTypeConversion flags it; server returns 400.
+            FieldDefinition fld = null;
+            try
+            {
+                fld = await client.FieldDefinitionsClient.CreateFieldDefinitionAsync(new CreateFieldDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateFieldDefinitionRequest
+                    {
+                        Name = UniqueName("client_test_change_constraint"),
+                        FieldType = FieldType.String,
+                        Length = 25,
+                        Constraint = "^[A-Z]+$",
+                    }
+                }).ConfigureAwait(false);
+
+                var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                    await client.FieldDefinitionsClient.ChangeFieldTypeAsync(new ChangeFieldTypeParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        FieldId = fld.Id,
+                        Request = new ChangeFieldTypeRequest
+                        {
+                            NewFieldType = FieldType.Number,
+                            AllowDataLoss = false,
+                        },
+                    }).ConfigureAwait(false)).ConfigureAwait(false);
+
+                Assert.AreEqual(400, ex.StatusCode);
+            }
+            finally
+            {
+                if (fld != null) await TryDeleteField(fld.Id);
+            }
+        }
+    }
+}

--- a/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
+++ b/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
@@ -1,0 +1,406 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+using Laserfiche.Api.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
+{
+    /// <summary>
+    /// Integration tests for the template-definition admin endpoints introduced by PRD 6.3.C:
+    /// Create / Update / Delete + GetAssignedEntryCount + Get/UpdateProperties +
+    /// AddField / UpdateFieldProperties / RemoveField / MoveField.
+    /// </summary>
+    [TestClass]
+    public class TemplateAdminTest : BaseTest
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            client = CreateClient();
+        }
+
+        private static string UniqueName(string prefix) =>
+            $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid().ToString("N").Substring(0, 6)}";
+
+        // The admin tests reuse existing repository field definitions rather than creating
+        // their own. 6.3.C is independent of 6.3.A so CreateFieldDefinition isn't on the
+        // base swagger; we pick from what dev-CA already has.
+        private async Task<string[]> PickExistingFieldNamesAsync(int count)
+        {
+            var fields = await client.FieldDefinitionsClient.ListFieldDefinitionsAsync(new ListFieldDefinitionsParameters
+            {
+                RepositoryId = RepositoryId,
+            }).ConfigureAwait(false);
+            var names = fields.Value?
+                .Where(f => !string.IsNullOrEmpty(f.Name))
+                .Select(f => f.Name)
+                .Take(count)
+                .ToArray() ?? Array.Empty<string>();
+            Assert.IsTrue(names.Length >= count, $"Need at least {count} existing field definition(s) in dev-CA repository; found {names.Length}.");
+            return names;
+        }
+
+        private async Task SafeDeleteTemplateAsync(int templateId)
+        {
+            if (templateId <= 0) return;
+            try
+            {
+                await client.TemplateDefinitionsClient.DeleteTemplateAsync(new DeleteTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = templateId,
+                }).ConfigureAwait(false);
+            }
+            catch (Exception cleanupEx)
+            {
+                // Don't fail the test on cleanup error (so an earlier assertion isn't masked),
+                // but log it so an orphan template doesn't accumulate silently across runs.
+                Console.WriteLine($"[TemplateAdminTest cleanup] DeleteTemplate id={templateId} failed: {cleanupEx.GetType().Name}: {cleanupEx.Message}");
+            }
+        }
+
+        [TestMethod]
+        public async Task CreateUpdateDelete_Template_Lifecycle()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                // Create
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest
+                    {
+                        Name = templateName,
+                        Description = "Created from .NET client integration test",
+                        IsAutoAssignable = false,
+                        Color = new LFColor { A = 255, R = 100, G = 50, B = 25 },
+                    }
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(created);
+                Assert.IsTrue(created.Id > 0);
+                Assert.AreEqual(templateName, created.Name);
+                Assert.AreEqual("Created from .NET client integration test", created.Description);
+                Assert.IsFalse(created.IsAutoAssignable);
+                Assert.IsNotNull(created.Color);
+                Assert.AreEqual((byte)100, created.Color.R);
+                createdId = created.Id;
+
+                // Update — rename + flip IsAutoAssignable
+                string renamed = UniqueName("client_test_tmpl_renamed");
+                var updated = await client.TemplateDefinitionsClient.UpdateTemplateAsync(new UpdateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplateRequest
+                    {
+                        Name = renamed,
+                        IsAutoAssignable = true,
+                    }
+                }).ConfigureAwait(false);
+                Assert.AreEqual(renamed, updated.Name);
+                Assert.IsTrue(updated.IsAutoAssignable);
+
+                // Independent GET to confirm persistence
+                var readBack = await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(renamed, readBack.Name);
+                Assert.IsTrue(readBack.IsAutoAssignable);
+
+                // Delete
+                int deletedId = createdId;
+                await client.TemplateDefinitionsClient.DeleteTemplateAsync(new DeleteTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                createdId = 0;
+
+                // 404 after delete — verify the just-deleted template is actually gone, and
+                // that the response is a structured ProblemDetails (not a coarse network 404).
+                var ex = await Assert.ThrowsExceptionAsync<ApiException>(async () =>
+                {
+                    await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        TemplateId = deletedId,
+                    }).ConfigureAwait(false);
+                });
+                Assert.AreEqual(404, ex.StatusCode, $"Expected 404 from GET on deleted template id={deletedId}, got {ex.StatusCode}");
+                Assert.IsNotNull(ex.ProblemDetails, "Expected a ProblemDetails body on the 404 response (not a coarse infrastructure 404).");
+                Assert.AreEqual(404, ex.ProblemDetails.Status, "ProblemDetails.Status should mirror the HTTP status.");
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task UpdateTemplate_ClearColor_SetsColorToNull()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest
+                    {
+                        Name = templateName,
+                        Color = new LFColor { A = 255, R = 30, G = 60, B = 90 },
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+                Assert.IsNotNull(created.Color);
+
+                await client.TemplateDefinitionsClient.UpdateTemplateAsync(new UpdateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplateRequest { ClearColor = true }
+                }).ConfigureAwait(false);
+
+                var readBack = await client.TemplateDefinitionsClient.GetTemplateDefinitionAsync(new GetTemplateDefinitionParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsNull(readBack.Color, "Color should be cleared after ClearColor=true");
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task AddRemoveMoveField_Lifecycle()
+        {
+            var fieldNames = await PickExistingFieldNamesAsync(3);
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest { Name = templateName }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+                Assert.AreEqual(0, created.FieldCount);
+
+                // Add three fields
+                foreach (var name in fieldNames)
+                {
+                    await client.TemplateDefinitionsClient.AddTemplateFieldAsync(new AddTemplateFieldParameters
+                    {
+                        RepositoryId = RepositoryId,
+                        TemplateId = createdId,
+                        Request = new AddTemplateFieldRequest { FieldName = name }
+                    }).ConfigureAwait(false);
+                }
+
+                // Read back: 3 fields, in addition order
+                var fieldsAfterAdd = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(fieldsAfterAdd.Value);
+                Assert.AreEqual(3, fieldsAfterAdd.Value.Count);
+                CollectionAssert.AreEqual(fieldNames, fieldsAfterAdd.Value.Select(f => f.Name).ToArray());
+
+                // Move first field to position 3
+                await client.TemplateDefinitionsClient.MoveTemplateFieldAsync(new MoveTemplateFieldParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new MoveTemplateFieldRequest { FieldName = fieldNames[0], NewPosition = 3 }
+                }).ConfigureAwait(false);
+
+                var fieldsAfterMove = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(3, fieldsAfterMove.Value.Count);
+                Assert.AreEqual(fieldNames[0], fieldsAfterMove.Value[2].Name, "Moved field should now be at position 3");
+
+                // Remove middle field
+                await client.TemplateDefinitionsClient.RemoveTemplateFieldAsync(new RemoveTemplateFieldParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    FieldName = fieldNames[1],
+                }).ConfigureAwait(false);
+
+                var fieldsAfterRemove = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual(2, fieldsAfterRemove.Value.Count);
+                Assert.IsFalse(fieldsAfterRemove.Value.Any(f => f.Name == fieldNames[1]));
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task UpdateTemplateFieldProperties_IsRequired_RoundTrip()
+        {
+            // Note: LocalDescription is intentionally not exercised here. The
+            // underlying RA `SetFieldLocalDescription` requires LFS ≥ 12.0.2,
+            // which dev-CA runs older than at the time this test was authored.
+            // The contract still covers it on the API surface (controller test +
+            // server-side unit tests verify the LocalDescription branch).
+            var fieldNames = await PickExistingFieldNamesAsync(1);
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest
+                    {
+                        Name = templateName,
+                        Fields = new List<TemplateFieldAssignment>
+                        {
+                            new TemplateFieldAssignment { FieldName = fieldNames[0], IsRequired = false }
+                        }
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var before = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                var beforeField = before.Value.Single();
+                Assert.IsFalse(beforeField.IsRequired);
+
+                await client.TemplateDefinitionsClient.UpdateTemplateFieldPropertiesAsync(new UpdateTemplateFieldPropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    FieldName = fieldNames[0],
+                    Request = new UpdateTemplateFieldPropertiesRequest { IsRequired = true }
+                }).ConfigureAwait(false);
+
+                var after = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                var afterField = after.Value.Single();
+                Assert.IsTrue(afterField.IsRequired, "IsRequired should now be true");
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task Properties_RoundTrip()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest { Name = templateName }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                // Set initial keys
+                var first = await client.TemplateDefinitionsClient.UpdateTemplatePropertiesAsync(new UpdateTemplatePropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplatePropertiesRequest
+                    {
+                        Set = new Dictionary<string, string>
+                        {
+                            { "test.prop.one", "value-one" },
+                            { "test.prop.two", "value-two" },
+                        }
+                    }
+                }).ConfigureAwait(false);
+                Assert.IsTrue(first.Properties.ContainsKey("test.prop.one"));
+                Assert.AreEqual("value-one", first.Properties["test.prop.one"]);
+                Assert.AreEqual("value-two", first.Properties["test.prop.two"]);
+
+                // Independent GET
+                var readBack = await client.TemplateDefinitionsClient.GetTemplatePropertiesAsync(new GetTemplatePropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.AreEqual("value-one", readBack.Properties["test.prop.one"]);
+
+                // Remove one, overwrite the other
+                var afterPatch = await client.TemplateDefinitionsClient.UpdateTemplatePropertiesAsync(new UpdateTemplatePropertiesParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Request = new UpdateTemplatePropertiesRequest
+                    {
+                        Set = new Dictionary<string, string> { { "test.prop.two", "value-two-updated" } },
+                        Remove = new List<string> { "test.prop.one" },
+                    }
+                }).ConfigureAwait(false);
+                Assert.IsFalse(afterPatch.Properties.ContainsKey("test.prop.one"), "test.prop.one should be removed");
+                Assert.AreEqual("value-two-updated", afterPatch.Properties["test.prop.two"]);
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetTemplateAssignedEntryCount_NewTemplate_ReturnsZero()
+        {
+            string templateName = UniqueName("client_test_tmpl");
+            int createdId = 0;
+            try
+            {
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest { Name = templateName }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
+
+                var count = await client.TemplateDefinitionsClient.GetTemplateAssignedEntryCountAsync(new GetTemplateAssignedEntryCountParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                }).ConfigureAwait(false);
+                Assert.IsNotNull(count);
+                Assert.AreEqual(0, count.Count, "A fresh template should have zero assigned entries");
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

One consolidated regen bringing the V2 client up to the **full deployed V2 surface**, superseding the conflicting per-batch client PRs. Each per-batch PR regenerated the whole `RepositoryClients.cs`, so they conflicted with each other; since the server now carries everything, a single regen is clean. 6.3.A (#202) is already on `v2`.

## Surface added since v2
- **6.3.B** — Field Definition destructive ops: `MergeFields`, `ChangeFieldType`
- **6.3.C** — Template Definition admin: CRUD + Properties + Field management
- **REQ-DOC-002** — Entry introspection on GET Entry: opt-in `includeChildInfo` returning a flat `childInfo` object `{ hasChildren, childCount, folderCount, documentCount, shortcutCount }`, plus `includeTotalSize`

## Supersedes
- #203 (6.3.C) — closed in favor of this
- the never-opened 6.3.B `story/669513` branch

## Notes
- Regenerated off the deployed swagger; committed `generate-client/swagger.json` normalized to **production** URLs (`api.laserfiche.com` / `signin.laserfiche.com`). Generated client bakes no base URL.
- Integration tests for 6.3.B / 6.3.C / REQ-DOC-002 on this branch; childInfo test asserts the flat single-object shape.
- `patch_optional_multipart` applied (22 null-checks). Unit tests 3/3; integration tests run in CI against the deployed cloud.