### PR TITLE
Changelog: 2.2.0 — field & template definition admin and entry introspection (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.2.0
+
+### Features
+
+- Add field definition administration methods: `CreateFieldDefinitionAsync`, `UpdateFieldDefinitionAsync`, `DeleteFieldDefinitionAsync`, `GetFieldListValuesAsync`, `ReplaceFieldListValuesAsync`, `GetFieldContainingTemplatesAsync`, `GetFieldAssignedEntryCountAsync`, `GetFieldPropertiesAsync`, `UpdateFieldPropertiesAsync`.
+- Add destructive field operations: `MergeFieldsAsync` and `ChangeFieldTypeAsync`, both gated by an explicit `allowDataLoss` flag — a request that would lose data is rejected unless `allowDataLoss` is `true`.
+- Add template definition administration methods: `CreateTemplateAsync`, `UpdateTemplateAsync`, `DeleteTemplateAsync`, `GetTemplateAssignedEntryCountAsync`, `GetTemplatePropertiesAsync`, `UpdateTemplatePropertiesAsync`, `AddTemplateFieldAsync`, `UpdateTemplateFieldPropertiesAsync`, `RemoveTemplateFieldAsync`, `MoveTemplateFieldAsync`.
+- `GetEntryAsync` accepts opt-in `includeChildInfo` (folder entries — immediate-children counts: `hasChildren`, `childCount`, `folderCount`, `documentCount`, `shortcutCount`) and `includeTotalSize` (document entries — full stored size including page data, distinct from `electronicDocumentSize`). Both are omitted from the response unless requested.
+- New types: request/response DTOs for field and template definition administration, and the `childInfo` object on the entry response.
+
 ## 2.1.0
 
 ### Features


### PR DESCRIPTION
Adds the `2.2.0` CHANGELOG entry for the Phase 2 surface (PRD 6.3 + REQ-DOC-002), which already landed on `v2` via the consolidated regen PR #204:

- Field definition administration (CRUD, list values, containing templates, assigned-entry count, extended properties)
- Destructive field operations (`MergeFieldsAsync`, `ChangeFieldTypeAsync`) gated by `allowDataLoss`
- Template definition administration (CRUD, properties, per-template field management)
- `GetEntryAsync` opt-in `includeChildInfo` / `includeTotalSize`

**Merge timing:** this is CHANGELOG-only. Because a merge to `v2` triggers the NuGet publish pipeline, fold this in with the stable `2.2.0` release (the `VERSION_PREFIX` bump in `.github/workflows/main.yml` from `2.1.0` to `2.2.0`) when the server surface reaches production — rather than merging standalone.