### PR TITLE
Regen V2 client from string-extent swagger (revert LockExtent enum)

### DIFF
--- a/generate-client/swagger.json
+++ b/generate-client/swagger.json
@@ -14595,55 +14595,11 @@
             "nullable": true
           },
           "extent": {
-            "description": "The lock extent. Defaults to All when omitted.",
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/LockExtent"
-              }
-            ]
+            "type": "string",
+            "description": "The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted.",
+            "nullable": true
           }
         }
-      },
-      "LockExtent": {
-        "type": "string",
-        "description": "The portion of a document that a persistent lock covers.",
-        "x-enum-names": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-varnames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enumNames": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ],
-        "x-enum-descriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "x-enumDescriptions": [
-          null,
-          null,
-          null,
-          null
-        ],
-        "enum": [
-          "Page",
-          "Edoc",
-          "Metadata",
-          "All"
-        ]
       },
       "CheckOutDocumentRequest": {
         "type": "object",

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -24021,32 +24021,10 @@ namespace Laserfiche.Repository.Api.Client
         public string Comment { get; set; }
 
         /// <summary>
-        /// The lock extent. Defaults to All when omitted.
+        /// The lock extent. One of: Page, Edoc, Metadata, All. Defaults to All when omitted.
         /// </summary>
         [Newtonsoft.Json.JsonProperty("extent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-        public LockExtent? Extent { get; set; }
-
-    }
-
-    /// <summary>
-    /// The portion of a document that a persistent lock covers.
-    /// </summary>
-    [GeneratedCode("NJsonSchema", "14.4.0.0 (NJsonSchema v11.3.2.0 (Newtonsoft.Json v13.0.0.0))")]
-    public enum LockExtent
-    {
-
-        [EnumMember(Value = @"Page")]
-        Page = 0,
-
-        [EnumMember(Value = @"Edoc")]
-        Edoc = 1,
-
-        [EnumMember(Value = @"Metadata")]
-        Metadata = 2,
-
-        [EnumMember(Value = @"All")]
-        All = 3,
+        public string Extent { get; set; }
 
     }
 

--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -236,8 +236,35 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
             return newEntry;
         }
 
+        // Cached per test run; the repository's audit-reason list is static test fixture data.
+        private static int? deleteEntryAuditReasonId;
+        private static bool deleteEntryAuditReasonResolved;
+
+        /// <summary>
+        /// Returns the id of a DeleteEntry audit reason, or null if the repository has none.
+        /// The shared test repository's audit policy requires a reason for DeleteEntry —
+        /// without one the async delete task deterministically reports Failed
+        /// (400 invalidRequest, "Need to provide correct audit reason for DeleteEntry").
+        /// </summary>
+        protected async Task<int?> GetDeleteEntryAuditReasonIdAsync()
+        {
+            if (!deleteEntryAuditReasonResolved)
+            {
+                var auditReasons = await client.AuditReasonsClient.ListAuditReasonsAsync(new ListAuditReasonsParameters()
+                {
+                    RepositoryId = RepositoryId
+                }).ConfigureAwait(false);
+                deleteEntryAuditReasonId = auditReasons.Value.FirstOrDefault(r => r.AuditEventType == AuditEventType.DeleteEntry)?.Id;
+                deleteEntryAuditReasonResolved = true;
+            }
+            return deleteEntryAuditReasonId;
+        }
+
         public async Task DeleteEntry(int entryId, StartDeleteEntryRequest request = null)
         {
+            // Default to a valid audit reason — without it the background delete silently fails
+            // and cleanup entries accumulate in the shared test repository.
+            request ??= new StartDeleteEntryRequest() { AuditReasonId = await GetDeleteEntryAuditReasonIdAsync().ConfigureAwait(false) };
             var operation = await client.EntriesClient.StartDeleteEntryAsync(new StartDeleteEntryParameters()
             {
                 RepositoryId = RepositoryId,

--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -329,6 +329,48 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
             return entry;
         }
 
+        // ---- Template-definition test helpers (shared by the template test classes) ----
+
+        protected static string UniqueName(string prefix) =>
+            $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid().ToString("N").Substring(0, 6)}";
+
+        // The template tests reuse existing repository field definitions rather than creating their
+        // own: 6.3.C is independent of 6.3.A, so CreateFieldDefinition isn't on the base swagger.
+        // Pick from whatever the repository already has.
+        protected async Task<string[]> PickExistingFieldNamesAsync(int count)
+        {
+            var fields = await client.FieldDefinitionsClient.ListFieldDefinitionsAsync(new ListFieldDefinitionsParameters
+            {
+                RepositoryId = RepositoryId,
+            }).ConfigureAwait(false);
+            var names = fields.Value?
+                .Where(f => !string.IsNullOrEmpty(f.Name))
+                .Select(f => f.Name)
+                .Take(count)
+                .ToArray() ?? Array.Empty<string>();
+            Assert.IsTrue(names.Length >= count, $"Need at least {count} existing field definition(s) in the test repository; found {names.Length}.");
+            return names;
+        }
+
+        // Best-effort template cleanup: never fail a test on a cleanup error (so an earlier assertion
+        // isn't masked), but log it so an orphan template doesn't accumulate silently across runs.
+        protected async Task SafeDeleteTemplateAsync(int templateId)
+        {
+            if (templateId <= 0) return;
+            try
+            {
+                await client.TemplateDefinitionsClient.DeleteTemplateAsync(new DeleteTemplateParameters
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = templateId,
+                }).ConfigureAwait(false);
+            }
+            catch (Exception cleanupEx)
+            {
+                Console.WriteLine($"[template cleanup] DeleteTemplate id={templateId} failed: {cleanupEx.GetType().Name}: {cleanupEx.Message}");
+            }
+        }
+
         protected static void AssertCollectionResponse(AttributeCollectionResponse response)
         {
             Assert.IsNotNull(response);

--- a/tests/integration/Entries/ListLinksTest.cs
+++ b/tests/integration/Entries/ListLinksTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Laserfiche.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
@@ -8,10 +9,25 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
     [TestClass]
     public class ListLinksTest : BaseTest
     {
+        IList<Entry> createdEntries;
+
         [TestInitialize]
         public void Initialize()
         {
             client = CreateClient();
+            createdEntries = new List<Entry>();
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            foreach (var entry in createdEntries)
+            {
+                if (entry != null)
+                {
+                    await DeleteEntry(entry.Id).ConfigureAwait(false);
+                }
+            }
         }
 
         [TestMethod]
@@ -46,33 +62,53 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
         [TestMethod]
         public async Task SimplePaging()
         {
-            int entryId = 1;
             int maxPageSize = 1;
+
+            // Arrange: create a source entry with two links so a second page is guaranteed,
+            // instead of paging the shared root entry — whose link count this suite doesn't
+            // control (exactly one leftover link there makes nextLink null and fails the test).
+            var sourceEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ListLinks SimplePaging Source").ConfigureAwait(false);
+            createdEntries.Add(sourceEntry);
+            var targetEntry1 = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ListLinks SimplePaging Target1").ConfigureAwait(false);
+            createdEntries.Add(targetEntry1);
+            var targetEntry2 = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net ListLinks SimplePaging Target2").ConfigureAwait(false);
+            createdEntries.Add(targetEntry2);
+
+            await client.EntriesClient.SetLinksAsync(new SetLinksParameters()
+            {
+                RepositoryId = RepositoryId,
+                EntryId = sourceEntry.Id,
+                Request = new SetLinksRequest()
+                {
+                    Links = new List<LinkToUpdate>
+                    {
+                        new LinkToUpdate { LinkDefinitionId = 1, OtherEntryId = targetEntry1.Id },
+                        new LinkToUpdate { LinkDefinitionId = 1, OtherEntryId = targetEntry2.Id }
+                    }
+                }
+            }).ConfigureAwait(false);
 
             // Initial request
             var linkCollectionResponse = await client.EntriesClient.ListLinksAsync(new ListLinksParameters()
             {
                 RepositoryId = RepositoryId,
-                EntryId = entryId,
+                EntryId = sourceEntry.Id,
                 Prefer = $"maxpagesize={maxPageSize}"
             }).ConfigureAwait(false);
-            
-            Assert.IsNotNull(linkCollectionResponse);
 
-            if (linkCollectionResponse.Value.Count == 0)
-            {
-                return; // There's no point testing if we don't have any such item.
-            }
+            Assert.IsNotNull(linkCollectionResponse);
+            Assert.AreNotEqual(0, linkCollectionResponse.Value.Count);
 
             var nextLink = linkCollectionResponse.OdataNextLink;
-            
+
             Assert.IsNotNull(nextLink);
             Assert.IsTrue(linkCollectionResponse.Value.Count <= maxPageSize);
 
             // Paging request
             linkCollectionResponse = await client.EntriesClient.ListLinksNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
-            
+
             Assert.IsNotNull(linkCollectionResponse);
+            Assert.AreNotEqual(0, linkCollectionResponse.Value.Count);
             Assert.IsTrue(linkCollectionResponse.Value.Count <= maxPageSize);
         }
     }

--- a/tests/integration/Entries/LockDocumentTest.cs
+++ b/tests/integration/Entries/LockDocumentTest.cs
@@ -38,7 +38,7 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Entries
             {
                 RepositoryId = RepositoryId,
                 EntryId = createdEntryId,
-                Request = new LockDocumentRequest() { Comment = "client test lock", Extent = LockExtent.All }
+                Request = new LockDocumentRequest() { Comment = "client test lock", Extent = "All" }
             }).ConfigureAwait(false);
 
             Assert.IsNotNull(lockResult);

--- a/tests/integration/Tasks/ListTasksTest.cs
+++ b/tests/integration/Tasks/ListTasksTest.cs
@@ -16,16 +16,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
         }
 
         [TestMethod]
-        // Deterministic failure on the shared dev-CA repo (r-00010029cf7e): the async
-        // StartDeleteEntry background op returns Failed, not Completed — this is NOT flaky.
-        // Kept ignored so the publish-gating integration-test job can go green; un-ignore once
-        // the server/LFS-side root-cause is fixed (work item #671227, server follow-up).
-        [Ignore("Blocked on dev-CA env: async StartDeleteEntry returns Failed; re-enable after server/LFS root-cause (#671227)")]
         public async Task ReturnStatus()
         {
             var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net GetOperationStatus").ConfigureAwait(false);
 
-            StartDeleteEntryRequest request = new();
+            // The repository's audit policy may require a reason for DeleteEntry; without one the
+            // background task deterministically reports Failed (400 invalidRequest, errorCode 216,
+            // "Need to provide correct audit reason for DeleteEntry") — root-caused under #671441.
+            StartDeleteEntryRequest request = new() { AuditReasonId = await GetDeleteEntryAuditReasonIdAsync().ConfigureAwait(false) };
             var result = await client.EntriesClient.StartDeleteEntryAsync(new StartDeleteEntryParameters()
             {
                 RepositoryId = RepositoryId,

--- a/tests/integration/TemplateDefinitions/ListTemplateDefinitionFieldsByTemplateNameTest.cs
+++ b/tests/integration/TemplateDefinitions/ListTemplateDefinitionFieldsByTemplateNameTest.cs
@@ -55,36 +55,54 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         [TestMethod]
         public async Task SimplePaging()
         {
-            var allTemplateDefinitions = await client.TemplateDefinitionsClient.ListTemplateDefinitionsAsync(new ListTemplateDefinitionsParameters()
-            {
-                RepositoryId = RepositoryId,
-            }).ConfigureAwait(false);
-            var firstTemplateDefinition = allTemplateDefinitions.Value?.FirstOrDefault();
-            
-            Assert.IsNotNull(firstTemplateDefinition);
-
             int maxPageSize = 1;
 
-            // Initial request
-            var templateDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateNameAsync(new ListTemplateFieldDefinitionsByTemplateNameParameters()
+            // Self-sufficient: create a dedicated template with two fields so paging at
+            // maxpagesize=1 deterministically yields a next link. Previously this paged the first
+            // template in the shared repository and asserted a next link unconditionally, which is
+            // brittle to repository state/drift (a 0- or 1-field template sorting first fails the
+            // assertion). See the field-assignment drift incident in WI #671441.
+            var fieldNames = await PickExistingFieldNamesAsync(2).ConfigureAwait(false);
+            string templateName = UniqueName("client_test_paging_tmpl");
+            int createdId = 0;
+            try
             {
-                RepositoryId = RepositoryId,
-                TemplateName = firstTemplateDefinition.Name,
-                Prefer = $"maxpagesize={maxPageSize}"
-            }).ConfigureAwait(false);
-            
-            Assert.IsNotNull(templateDefinitionCollectionResponse);
-            
-            var nextLink = templateDefinitionCollectionResponse.OdataNextLink;
-            
-            Assert.IsNotNull(nextLink);
-            Assert.IsTrue(templateDefinitionCollectionResponse.Value.Count <= maxPageSize);
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters()
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest()
+                    {
+                        Name = templateName,
+                        Fields = fieldNames.Select(n => new TemplateFieldAssignment() { FieldName = n }).ToList()
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
 
-            // Paging request
-            templateDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateNameNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
-            
-            Assert.IsNotNull(templateDefinitionCollectionResponse);
-            Assert.IsTrue(templateDefinitionCollectionResponse.Value.Count <= maxPageSize);
+                // Initial request
+                var templateDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateNameAsync(new ListTemplateFieldDefinitionsByTemplateNameParameters()
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateName = templateName,
+                    Prefer = $"maxpagesize={maxPageSize}"
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(templateDefinitionCollectionResponse);
+
+                var nextLink = templateDefinitionCollectionResponse.OdataNextLink;
+
+                Assert.IsNotNull(nextLink);
+                Assert.IsTrue(templateDefinitionCollectionResponse.Value.Count <= maxPageSize);
+
+                // Paging request
+                templateDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateNameNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
+
+                Assert.IsNotNull(templateDefinitionCollectionResponse);
+                Assert.IsTrue(templateDefinitionCollectionResponse.Value.Count <= maxPageSize);
+            }
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/tests/integration/TemplateDefinitions/ListTemplateFieldDefinitionsByTemplateIdTest.cs
+++ b/tests/integration/TemplateDefinitions/ListTemplateFieldDefinitionsByTemplateIdTest.cs
@@ -54,41 +54,53 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
         [TestMethod]
         public async Task SimplePaging()
         {
-            var allTemplateDefinitions = await client.TemplateDefinitionsClient.ListTemplateDefinitionsAsync(new ListTemplateDefinitionsParameters()
-            {
-                RepositoryId = RepositoryId,
-            }).ConfigureAwait(false);
-            var firstTemplateDefinition = allTemplateDefinitions.Value?.FirstOrDefault();
-            
-            Assert.IsNotNull(firstTemplateDefinition);
-
             int maxPageSize = 1;
 
-            // Initial request
-            var templateFieldDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters()
+            // Self-sufficient: create a dedicated template with two fields so paging at
+            // maxpagesize=1 deterministically yields a next link. Previously this paged the first
+            // template in the shared repository and assumed it had >= 2 fields, which is brittle to
+            // repository state/drift (a 0- or 1-field template sorting first fails the nextLink
+            // assertion). See the field-assignment drift incident in WI #671441.
+            var fieldNames = await PickExistingFieldNamesAsync(2).ConfigureAwait(false);
+            int createdId = 0;
+            try
             {
-                RepositoryId = RepositoryId,
-                TemplateId = firstTemplateDefinition.Id,
-                Prefer = $"maxpagesize={maxPageSize}"
-            }).ConfigureAwait(false);
-            
-            Assert.IsNotNull(templateFieldDefinitionCollectionResponse);
+                var created = await client.TemplateDefinitionsClient.CreateTemplateAsync(new CreateTemplateParameters()
+                {
+                    RepositoryId = RepositoryId,
+                    Request = new CreateTemplateRequest()
+                    {
+                        Name = UniqueName("client_test_paging_tmpl"),
+                        Fields = fieldNames.Select(n => new TemplateFieldAssignment() { FieldName = n }).ToList()
+                    }
+                }).ConfigureAwait(false);
+                createdId = created.Id;
 
-            if (templateFieldDefinitionCollectionResponse.Value.Count == 0)
-            {
-                return; // There's no point testing if we don't have any such item.
+                // Initial request
+                var templateFieldDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdAsync(new ListTemplateFieldDefinitionsByTemplateIdParameters()
+                {
+                    RepositoryId = RepositoryId,
+                    TemplateId = createdId,
+                    Prefer = $"maxpagesize={maxPageSize}"
+                }).ConfigureAwait(false);
+
+                Assert.IsNotNull(templateFieldDefinitionCollectionResponse);
+
+                var nextLink = templateFieldDefinitionCollectionResponse.OdataNextLink;
+
+                Assert.IsNotNull(nextLink);
+                Assert.IsTrue(templateFieldDefinitionCollectionResponse.Value.Count <= maxPageSize);
+
+                // Paging request
+                templateFieldDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
+
+                Assert.IsNotNull(templateFieldDefinitionCollectionResponse);
+                Assert.IsTrue(templateFieldDefinitionCollectionResponse.Value.Count <= maxPageSize);
             }
-
-            var nextLink = templateFieldDefinitionCollectionResponse.OdataNextLink;
-            
-            Assert.IsNotNull(nextLink);
-            Assert.IsTrue(templateFieldDefinitionCollectionResponse.Value.Count <= maxPageSize);
-
-            // Paging request
-            templateFieldDefinitionCollectionResponse = await client.TemplateDefinitionsClient.ListTemplateFieldDefinitionsByTemplateIdNextLinkAsync(nextLink, maxPageSize).ConfigureAwait(false);
-            
-            Assert.IsNotNull(templateFieldDefinitionCollectionResponse);
-            Assert.IsTrue(templateFieldDefinitionCollectionResponse.Value.Count <= maxPageSize);
+            finally
+            {
+                await SafeDeleteTemplateAsync(createdId).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
+++ b/tests/integration/TemplateDefinitions/TemplateAdminTest.cs
@@ -23,46 +23,6 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.TemplateDefinitions
             client = CreateClient();
         }
 
-        private static string UniqueName(string prefix) =>
-            $"{prefix}_{DateTime.UtcNow:yyyyMMdd_HHmmss_fff}_{Guid.NewGuid().ToString("N").Substring(0, 6)}";
-
-        // The admin tests reuse existing repository field definitions rather than creating
-        // their own. 6.3.C is independent of 6.3.A so CreateFieldDefinition isn't on the
-        // base swagger; we pick from what dev-CA already has.
-        private async Task<string[]> PickExistingFieldNamesAsync(int count)
-        {
-            var fields = await client.FieldDefinitionsClient.ListFieldDefinitionsAsync(new ListFieldDefinitionsParameters
-            {
-                RepositoryId = RepositoryId,
-            }).ConfigureAwait(false);
-            var names = fields.Value?
-                .Where(f => !string.IsNullOrEmpty(f.Name))
-                .Select(f => f.Name)
-                .Take(count)
-                .ToArray() ?? Array.Empty<string>();
-            Assert.IsTrue(names.Length >= count, $"Need at least {count} existing field definition(s) in dev-CA repository; found {names.Length}.");
-            return names;
-        }
-
-        private async Task SafeDeleteTemplateAsync(int templateId)
-        {
-            if (templateId <= 0) return;
-            try
-            {
-                await client.TemplateDefinitionsClient.DeleteTemplateAsync(new DeleteTemplateParameters
-                {
-                    RepositoryId = RepositoryId,
-                    TemplateId = templateId,
-                }).ConfigureAwait(false);
-            }
-            catch (Exception cleanupEx)
-            {
-                // Don't fail the test on cleanup error (so an earlier assertion isn't masked),
-                // but log it so an orphan template doesn't accumulate silently across runs.
-                Console.WriteLine($"[TemplateAdminTest cleanup] DeleteTemplate id={templateId} failed: {cleanupEx.GetType().Name}: {cleanupEx.Message}");
-            }
-        }
-
         [TestMethod]
         public async Task CreateUpdateDelete_Template_Lifecycle()
         {


### PR DESCRIPTION
Re-generates `src/Clients/RepositoryClients.cs` + `swagger.json` from the server with `LockDocumentRequest.Extent` reverted to **string**, dropping the breaking `LockExtent` enum the prior regen introduced. Preserves the GA'd 2.1.0 `extent` contract and keeps this client **non-breaking** (stays 2.2.0 minor). Full Phase 2 surface (6.3.A/B/C + REQ-DOC-002) retained. Pairs with the server contract revert (TFS site-api-repository PR #172468 / work item #671200). Also updates the client Lock integration test to pass `extent` as a string.

### Integration-test stabilization (folded in, work item #671441)

Several integration tests were red or flaky because they depended on uncontrolled **shared dev-CA repository state**. Each is now **self-sufficient** — it arranges the data it needs and cleans up — so it passes regardless of what else is in the repo:

- **`ListTasksTest.ReturnStatus`** (`d3291ca`, from closed PR #209): un-ignored + fixed. The repo's audit policy requires a `DeleteEntry` audit reason; the test sent an empty `StartDeleteEntryRequest`, so the background task always reported `Failed` (`400 invalidRequest`, errorCode 216). `BaseTest` now resolves a `DeleteEntry` audit reason via `ListAuditReasons` (cached per run; null-safe fallback) and defaults `DeleteEntry` requests to it — which also stops the suite's cleanup deletes from silently failing and littering the shared repo.
- **`ListLinksTest.SimplePaging`** (`652aeb3`): paged the shared root entry's links and required a second page, so it failed deterministically whenever exactly one leftover link existed on entry 1. Now creates its own source entry with two links (same pattern as `SetLinksTest`), guaranteeing a next page.
- **`ListTemplateFieldDefinitionsByTemplateIdTest.SimplePaging` + `ListTemplateDefinitionFieldsByTemplateNameTest.SimplePaging`** (`4685ad2`): paged the *first* template in the repo and assumed it had >= 2 fields (asserting a non-null next link at `maxpagesize=1`) — the by-name variant had no guard at all, so a 0- or 1-field template sorting first failed it. Each now creates a dedicated template seeded with two existing field definitions, pages over it, and deletes it in `finally`. Shared `UniqueName` / `PickExistingFieldNamesAsync` / `SafeDeleteTemplateAsync` helpers were hoisted into `BaseTest`.

### Verification

- Client solution builds clean; `site-api-repository`'s `SiteApiRepositoryREST` compiles against this client both via `UseLocalClientLib=true` and against the pinned preview NuGet.
- The string-contract + Phase 2 server is now **deployed to dev-CA**, and against it the integration suite is green (**130/132**): `ReturnStatus`, `ListLinks`, and all template read/admin/paging tests pass. The 2 failures are `CheckInCheckOutTest.CheckIn_WithUnlockFalse_KeepsLock` / `CheckIn_DefaultUnlock_ReleasesLock`, both `TaskCanceledException` from `HttpClient.Timeout` (100s/180s) in their `CreateDocument`/`ImportEntry` setup (one in the OAuth token fetch) — the known dev-CA long-op/import timeout flake, unrelated to this PR and aggravated by concurrent dev-CA load. A re-run is expected to clear them.
