### PR TITLE
Un-ignore ReturnStatus: pass required DeleteEntry audit reason

### DIFF
--- a/tests/integration/BaseTest.cs
+++ b/tests/integration/BaseTest.cs
@@ -236,8 +236,35 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest
             return newEntry;
         }
 
+        // Cached per test run; the repository's audit-reason list is static test fixture data.
+        private static int? deleteEntryAuditReasonId;
+        private static bool deleteEntryAuditReasonResolved;
+
+        /// <summary>
+        /// Returns the id of a DeleteEntry audit reason, or null if the repository has none.
+        /// The shared test repository's audit policy requires a reason for DeleteEntry —
+        /// without one the async delete task deterministically reports Failed
+        /// (400 invalidRequest, "Need to provide correct audit reason for DeleteEntry").
+        /// </summary>
+        protected async Task<int?> GetDeleteEntryAuditReasonIdAsync()
+        {
+            if (!deleteEntryAuditReasonResolved)
+            {
+                var auditReasons = await client.AuditReasonsClient.ListAuditReasonsAsync(new ListAuditReasonsParameters()
+                {
+                    RepositoryId = RepositoryId
+                }).ConfigureAwait(false);
+                deleteEntryAuditReasonId = auditReasons.Value.FirstOrDefault(r => r.AuditEventType == AuditEventType.DeleteEntry)?.Id;
+                deleteEntryAuditReasonResolved = true;
+            }
+            return deleteEntryAuditReasonId;
+        }
+
         public async Task DeleteEntry(int entryId, StartDeleteEntryRequest request = null)
         {
+            // Default to a valid audit reason — without it the background delete silently fails
+            // and cleanup entries accumulate in the shared test repository.
+            request ??= new StartDeleteEntryRequest() { AuditReasonId = await GetDeleteEntryAuditReasonIdAsync().ConfigureAwait(false) };
             var operation = await client.EntriesClient.StartDeleteEntryAsync(new StartDeleteEntryParameters()
             {
                 RepositoryId = RepositoryId,

--- a/tests/integration/Tasks/ListTasksTest.cs
+++ b/tests/integration/Tasks/ListTasksTest.cs
@@ -16,16 +16,14 @@ namespace Laserfiche.Repository.Api.Client.IntegrationTest.Tasks
         }
 
         [TestMethod]
-        // Deterministic failure on the shared dev-CA repo (r-00010029cf7e): the async
-        // StartDeleteEntry background op returns Failed, not Completed — this is NOT flaky.
-        // Kept ignored so the publish-gating integration-test job can go green; un-ignore once
-        // the server/LFS-side root-cause is fixed (work item #671227, server follow-up).
-        [Ignore("Blocked on dev-CA env: async StartDeleteEntry returns Failed; re-enable after server/LFS root-cause (#671227)")]
         public async Task ReturnStatus()
         {
             var deleteEntry = await CreateEntry(client, "RepositoryApiClientIntegrationTest .Net GetOperationStatus").ConfigureAwait(false);
 
-            StartDeleteEntryRequest request = new();
+            // The repository's audit policy may require a reason for DeleteEntry; without one the
+            // background task deterministically reports Failed (400 invalidRequest, errorCode 216,
+            // "Need to provide correct audit reason for DeleteEntry") — root-caused under #671441.
+            StartDeleteEntryRequest request = new() { AuditReasonId = await GetDeleteEntryAuditReasonIdAsync().ConfigureAwait(false) };
             var result = await client.EntriesClient.StartDeleteEntryAsync(new StartDeleteEntryParameters()
             {
                 RepositoryId = RepositoryId,


### PR DESCRIPTION
## Problem

`ListTasksTest.ReturnStatus` was `[Ignore]`d (#208) because the async `StartDeleteEntry` task deterministically reported `Failed` on the shared dev-CA repository. Root cause (TFS work item #671441): the repository's audit policy requires an audit reason for DeleteEntry, and the test sent an empty `StartDeleteEntryRequest`. The task's error detail (which the test never read) was:

```
400 invalidRequest, errorCode 216,
"Error: Need to provide correct audit reason for DeleteEntry" (instanceDetail: auditReasonId)
```

Side finding: every `BaseTest.DeleteEntry` cleanup call in the suite was silently failing the same way — callers only assert `TaskId != null` and never poll, so the background failures went unnoticed and cleanup entries accumulated in the shared test repository.

## Fix (test-only)

- `BaseTest.GetDeleteEntryAuditReasonIdAsync()`: resolves a `DeleteEntry`-type audit reason via `ListAuditReasons` (cached per run; `null` fallback when the repository defines none, preserving the previous request shape for lenient environments).
- `ReturnStatus`: passes the resolved `AuditReasonId`; `[Ignore]` removed.
- `BaseTest.DeleteEntry`: defaults a `null` request to the resolved audit reason so cleanup deletes actually complete.

Supplying a reason where it is not required is legal (it is just recorded in the audit trail), and environments with no reasons defined get the exact pre-fix request — so this is strictly more permissive across environments.

## Validation (against deployed dev-CA)

- `ReturnStatus`: passes (previously `Failed` on every run)
- `EntryIntrospectionTest` (uses the modified `DeleteEntry` helper): 4/4 pass