### PR TITLE
Release 2.2.0: bump VERSION_PREFIX for the stable client publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   API_VERSION: 'v2'
-  VERSION_PREFIX: '2.1.0'
+  VERSION_PREFIX: '2.2.0'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 
 jobs:


### PR DESCRIPTION
Bumps `VERSION_PREFIX` 2.1.0 → 2.2.0 so the production publish job ships the **2.2.0** stable release of `Laserfiche.Repository.Api.Client.V2` (US #670529).

The 2.2.0 changelog is already on `v2` and covers the Phase-2 surface: field/template-definition administration (CRUD, list values, introspection, merge/change-type with the allowDataLoss gate, template field management) and the entry `childInfo` object. **No Dynamic Fields / external-table surface** — REQ-ADMIN-008 was abandoned.

After merge to `v2`: re-run the CI (attempt 2+) and approve the production environment so `publish-production-package` ships 2.2.0. (Latest published stable is 2.1.0; no 2.2.0 exists yet.)