### PR TITLE
infra: normalize swagger servers[] to the production URL in download_swagger.py

### DIFF
--- a/generate-client/download_swagger.py
+++ b/generate-client/download_swagger.py
@@ -30,12 +30,24 @@ def replace_with_override_data(json_data, json_override_data):
 
 def sort_status_codes(json_data):
     '''
-    Sorts the status codes for each api route. 
+    Sorts the status codes for each api route.
     '''
     for path_element in json_data['paths'].values():
         for api_element in path_element.values():
             if 'responses' in api_element:
                 api_element['responses'] = dict(sorted(api_element['responses'].items(), key=lambda item: item[0]))
+    return json_data
+
+def normalize_servers(json_data, canonical_url):
+    '''
+    Forces the OpenAPI servers[] to the canonical (production) URL. A swagger document downloaded
+    from a locally-running server carries that server's host (e.g. http://localhost:11211/repository),
+    which NSwag otherwise bakes into the generated client's baseUrl default. Normalizing here makes the
+    production URL the unconditional default regardless of the regen source; pass an empty canonical_url
+    to keep the source servers as-is (the only way to intentionally bake a localhost default).
+    '''
+    if canonical_url:
+        json_data['servers'] = [{'url': canonical_url}]
     return json_data
 
 
@@ -48,6 +60,11 @@ if __name__ == '__main__':
                         help='Optional json file with override values to replace in the swagger file.')
     parser.add_argument('--output-filepath',
                         help='Downloads the swagger file to this filepath.')
+    parser.add_argument('--canonical-server-url',
+                        default='https://api.laserfiche.com/repository',
+                        help='Force the OpenAPI servers[] to this URL so a local/dev swagger source '
+                             'never bakes its host into the generated client baseUrl default. '
+                             'Pass an empty string to keep the source servers as-is.')
     args = parser.parse_args()
 
     if args.swagger_url is None:
@@ -58,6 +75,7 @@ if __name__ == '__main__':
 
     swagger_json = download_file_to_json(args.swagger_url)
     swagger_json = sort_status_codes(swagger_json)
+    swagger_json = normalize_servers(swagger_json, args.canonical_server_url)
 
     if args.swagger_override_filepath is not None:
         with open(args.swagger_override_filepath, 'r') as swagger_override_file:


### PR DESCRIPTION
Regen-tooling fix for the recurring localhost-baking trap: regenerating the client against a local server bakes `http://localhost:11211` into the swagger `servers[]` (and, for the JS client, every generated baseUrl default), requiring a manual restore on each regen.

`download_swagger.py` now forces `servers[]` to the canonical production URL by default (`--canonical-server-url`; pass an empty string to keep the source URL).

Split out of the 6.4.B/C/D feature work (#213) per the agreed 'infra fix ships in its own PR' convention — this PR is tooling-only and does not change the generated client surface.