### PR TITLE
Release 2.3.0: bump VERSION_PREFIX for the stable client publish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   API_VERSION: 'v2'
-  VERSION_PREFIX: '2.2.0'
+  VERSION_PREFIX: '2.3.0'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.3.0
+
+### Features
+
+- Add Records Management methods, exposed on the new `RecordsManagementClient`: `GetEntryRecordsManagementPropertiesAsync`, `UpdateEntryRecordsManagementPropertiesAsync`, `GetEligibleRecordsAsync`, `GetIndependentRecordsAsync`, `GetAltRetentionEventsAsync`, `GetRecordSeriesPropertiesAsync`, `UpdateRecordSeriesPropertiesAsync`, `SetRecordEventAsync`, `RemoveRecordEventAsync`, `CreateRecordSeriesAsync`.
+- Add unified access-rights/access-control methods for fields, templates, and entries, exposed on the new `AccessControlClient`: `GetFieldAccessControlAsync`/`SetFieldAccessControlAsync`, `GetFieldRightsAsync`, `GetDefaultFieldAccessControlAsync`/`SetDefaultFieldAccessControlAsync`, `GetEntryAccessControlAsync`/`SetEntryAccessControlAsync`, `GetEntryRightsAsync`, `GetSessionRightsAsync`, `GetTemplateAccessControlAsync`/`SetTemplateAccessControlAsync`, `GetTemplateRightsAsync`, `GetDefaultTemplateAccessControlAsync`/`SetDefaultTemplateAccessControlAsync`, `LookupTrusteesAsync`, `GetTrusteeSecurityAsync`.
+- Add User Areas methods, exposed on the new `UserAreasClient`: recent documents/folders (`GetRecentDocumentsAsync`, `GetRecentFoldersAsync`), starred entries (`GetStarredEntriesAsync`, `StarEntriesAsync`, `UnstarEntriesAsync`), personal collections (`GetPersonalCollectionsAsync`, `CreatePersonalCollectionAsync`, `GetPersonalCollectionAsync`, `RenamePersonalCollectionAsync`, `DeletePersonalCollectionAsync`, `AddCollectionEntriesAsync`, `RemoveCollectionEntriesAsync`), and generic user areas (`GetUserAreasAsync`, `CreateUserAreaAsync`, `GetUserAreaAsync`, `UpdateUserAreaAsync`, `DeleteUserAreaAsync`, `GetUserAreaEntriesAsync`, `AddUserAreaEntriesAsync`, `RemoveUserAreaEntriesAsync`).
+- Add Annotations & Stamps methods, exposed on the new `AnnotationsClient` and `StampsClient`: `ListDocumentAnnotationsAsync`, `ListPageAnnotationsAsync`, `CreateAnnotationAsync`, `GetAnnotationAsync`, `UpdateAnnotationAsync`, `DeleteAnnotationAsync`, `GetAnnotationAttachmentAsync`, `UploadAnnotationAttachmentAsync`, `UploadAnnotationImageAsync`, annotation reasons (`ListAnnotationReasonsAsync`, `CreateAnnotationReasonAsync`, `UpdateAnnotationReasonAsync`, `DeleteAnnotationReasonAsync`), and stamps (`ListStampsAsync`, `CreateStampAsync`, `GetStampAsync`, `UpdateStampAsync`, `DeleteStampAsync`, `GetStampImageAsync`).
+- New types: request/response DTOs for all of the above, plus discriminated-union types `Annotation` (14 subtypes: Highlight, Redaction, Strikeout, Underline, Note, Attachment, TextBox, Bitmap, Line, Rectangle, Polyline, Callout, Stamp, FreeHand) and `RecordsManagementProperties` (`RecordProperties`/`RecordFolderProperties`).
+
 ## 2.2.0
 
 ### Features


### PR DESCRIPTION
## Summary
- Bump `VERSION_PREFIX` in `.github/workflows/main.yml` from `2.2.0` to `2.3.0` for the Phase 3 combined surface (Records Management, Access Control/Rights, User Areas, Annotations & Stamps).
- Add the `2.3.0` CHANGELOG entry covering the new client surfaces merged in #215 and #219.

## Test plan
- [ ] CI build/pack succeeds with the new version
- [ ] Verify published NuGet version is `2.3.0` after merge