### PR TITLE
Fix publish-documentation job: grant contents:write permission

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,6 +271,8 @@ jobs:
     timeout-minutes: 10
     environment: github-pages
     needs: [ publish-production-package ]
+    permissions:
+      contents: write   # peter-evans/create-pull-request needs to push the docs branch
     steps:
     - name: Set DOCUMENTATION_VERSION environment variable
       run: |


### PR DESCRIPTION
## Summary
- `publish-documentation` (main.yml) never had its own `permissions:` block, so its `GITHUB_TOKEN` fell back to the repo-wide default, which is read-only.
- The job's last step (`peter-evans/create-pull-request@v4`) pushes a new `gh-pages-*-patch` branch, which needs `contents: write`. Every run failed with:
  ```
  remote: Permission to Laserfiche/lf-repository-api-client-dotnet.git denied to github-actions[bot].
  fatal: unable to access '...': The requested URL returned error: 403
  ##[error]The process '/usr/bin/git' failed with exit code 128
  ```
- `publish-preview-package` and `publish-production-package` already declare `contents: write` for the same reason; `publish-documentation` was just missing it.

## Test plan
- [ ] After merge, re-run (or wait for the next `v2` publish) and confirm `publish-documentation` succeeds and opens its doc-update PR instead of 403ing on push.