### PR TITLE
Switch V1 NuGet publish to Trusted Publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,9 @@ jobs:
     environment: preview
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
+    permissions:
+      id-token: write   # request the OIDC token for NuGet Trusted Publishing
+      contents: write   # the "Tag commit" step pushes a tag on the v1 branch
     steps:
     - uses: actions/checkout@v4
 
@@ -134,8 +137,18 @@ jobs:
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
 
+    # Trusted Publishing: exchange the GitHub OIDC token for a short-lived (1 hour)
+    # nuget.org API key. Requested immediately before the push so it doesn't expire.
+    # No long-lived NUGET_KEY secret required. See:
+    #   https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
+    - name: NuGet login (Trusted Publishing)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish to nuget.org
-      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1
@@ -151,6 +164,9 @@ jobs:
     environment: production
     if: ${{ github.run_attempt != 1 }}
     needs: [ build-n-test, build-documentation ] # wait for build to finish
+    permissions:
+      id-token: write   # request the OIDC token for NuGet Trusted Publishing
+      contents: write   # the "Tag commit" step pushes a tag on the v1 branch
     steps:
     - uses: actions/checkout@v4
 
@@ -171,8 +187,18 @@ jobs:
     - name: Packaging
       run: dotnet pack --no-build --configuration release /p:version=${{ env.PACKAGE_VERSION }}
 
-    - name: Publish to Nuget.org
-      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ secrets.NUGET_KEY }} --source https://api.nuget.org/v3/index.json
+    # Trusted Publishing: exchange the GitHub OIDC token for a short-lived (1 hour)
+    # nuget.org API key. Requested immediately before the push so it doesn't expire.
+    # No long-lived NUGET_KEY secret required. See:
+    #   https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing
+    - name: NuGet login (Trusted Publishing)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
+    - name: Publish to nuget.org
+      run: dotnet nuget push ./src/bin/Release/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
 
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1


### PR DESCRIPTION
## Summary

Switches the V1 CI pipeline from long-lived NuGet API-key publishing to GitHub OIDC **Trusted Publishing**, mirroring what was done for V2 in #200 (commit 59185c9).

Both publish jobs (`publish-preview-package` and `publish-production-package`) now:
- Declare `permissions: id-token: write` (request the OIDC token) and `contents: write` (for the existing tag-push step).
- Add a `NuGet login (Trusted Publishing)` step (`NuGet/login@v1`, `user: ${{ secrets.NUGET_USER }}`) that exchanges the OIDC token for a short-lived nuget.org key.
- Push with `${{ steps.nuget-login.outputs.NUGET_API_KEY }}` instead of `${{ secrets.NUGET_KEY }}`.

The long-lived `NUGET_KEY` secret is no longer referenced by the workflow.

## Scope

Only the Trusted Publishing swap is ported from the V2 commit. The V2-specific changes bundled in that commit (all-branch preview publishing, the integration-test job split, feature-branch preview versioning) are intentionally **not** included — they are preview-NuGet-workflow features that do not apply to the V1 maintenance line.

## nuget.org policy

No new policy required. The existing Trusted Publishing policy is scoped to this repository / workflow file (`.github/workflows/main.yml`) / environments (`preview`, `production`) and is not package-pinned, so it already authorizes V1 pushes of `Laserfiche.Repository.Api.Client` from the same repo and workflow. Trusted Publishing matches on the GitHub subject, which is branch-agnostic.

## Testing

- YAML validated.
- No behavioral change beyond the auth mechanism; the re-run-to-publish (`run_attempt != 1`) and environment gating are unchanged.