### PR TITLE
Regenerate V2 client for folderPath / autoCreateFolderPath (Epic #687490)

### DIFF
--- a/.claude/skills/regen-dotnet-client/SKILL.md
+++ b/.claude/skills/regen-dotnet-client/SKILL.md
@@ -115,6 +115,18 @@ dotnet test tests/unit/
 
 Then start a local `site-api-repository` server and run integration tests with the new method against it (see "Consuming the new client" below).
 
+> **`tests/integration/` is NOT where per-endpoint functional coverage belongs.** This suite and the
+> server-side `SiteApiRepositoryREST` suite drive the **identical generated client over HTTP**, so
+> duplicating an endpoint's happy/error/edge tests in both catches nothing extra — it's pure overlap.
+> The **server REST suite is the single canonical dotnet functional gate**. Keep `tests/integration/`
+> to **client-only** concerns: client construction/auth (`CreateFromAccessKey`,
+> `CreateFromHttpRequestHandler`, baseUrl override/trailing-slash tolerance), pagination helpers,
+> retry-when-locked, and `HttpClient.Timeout` override. Do **not** grow it per new endpoint. Running
+> a new method here once as a smoke check during regen is fine; committing a full per-endpoint suite
+> is the duplication to avoid. Full rationale: `site-api-repository/docs/analysis-dotnet-integration-test-overlap.md`.
+> (JS is different — its independent codebase makes `lf-api-js` functional tests genuinely
+> complementary, not overlap.)
+
 ## Consuming the new client
 
 ### Fast path — no publish needed

--- a/generate-client/swagger.json
+++ b/generate-client/swagger.json
@@ -4588,6 +4588,15 @@
             "x-position": 2
           },
           {
+            "name": "autoCreateFolderPath",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 4
+          },
+          {
             "name": "culture",
             "in": "query",
             "description": "An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.",
@@ -4596,7 +4605,7 @@
               "default": "",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 5
           }
         ],
         "requestBody": {
@@ -5502,6 +5511,15 @@
             "x-position": 2
           },
           {
+            "name": "autoCreateFolderPath",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 3
+          },
+          {
             "name": "culture",
             "in": "query",
             "description": "An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.",
@@ -5510,7 +5528,7 @@
               "default": "",
               "nullable": true
             },
-            "x-position": 3
+            "x-position": 4
           }
         ],
         "requestBody": {
@@ -6176,6 +6194,15 @@
             "x-position": 2
           },
           {
+            "name": "autoCreateFolderPath",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "x-position": 4
+          },
+          {
             "name": "culture",
             "in": "query",
             "description": "An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag.",
@@ -6184,7 +6211,7 @@
               "default": "",
               "nullable": true
             },
-            "x-position": 4
+            "x-position": 5
           }
         ],
         "requestBody": {
@@ -21645,6 +21672,11 @@
             "type": "string",
             "description": "The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.",
             "nullable": true
+          },
+          "folderPath": {
+            "type": "string",
+            "description": "An optional folder path, relative to the entry given in the route, that the document is imported into.\nBoth `/` and `\\` are accepted as separators. When any folder in this path does not exist, set the\n`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request\nfails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior).",
+            "nullable": true
           }
         }
       },
@@ -22587,6 +22619,11 @@
             "type": "boolean",
             "description": "Whether to generate searchable text (OCR) for image pages added via `imageFiles`. Default: true.\nDoes not affect pages generated from `file` \u2014 use `pdfOptions.generateText` for those.",
             "default": true
+          },
+          "folderPath": {
+            "type": "string",
+            "description": "An optional folder path, relative to the entry given in the route, that the document is imported into.\nBoth `/` and `\\` are accepted as separators. When any folder in this path does not exist, set the\n`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request\nfails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior).",
+            "nullable": true
           }
         }
       },
@@ -23066,6 +23103,11 @@
           "volumeName": {
             "type": "string",
             "description": "The name of the volume to use. Will use the default parent entry volume if not specified. This is ignored in Laserfiche Cloud.",
+            "nullable": true
+          },
+          "folderPath": {
+            "type": "string",
+            "description": "An optional folder path, relative to the entry given in the route, that the new entry is created under.\nBoth `/` and `\\` are accepted as separators. When any folder in this path does not exist, set the\n`autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request\nfails with 404. When omitted, the entry is created directly under the route entry (unchanged behavior).",
             "nullable": true
           }
         }

--- a/generate-client/swagger.json
+++ b/generate-client/swagger.json
@@ -4590,6 +4590,7 @@
           {
             "name": "autoCreateFolderPath",
             "in": "query",
+            "description": "When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -5513,6 +5514,7 @@
           {
             "name": "autoCreateFolderPath",
             "in": "query",
+            "description": "When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.",
             "schema": {
               "type": "boolean",
               "default": false
@@ -6196,6 +6198,7 @@
           {
             "name": "autoCreateFolderPath",
             "in": "query",
+            "description": "When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.",
             "schema": {
               "type": "boolean",
               "default": false

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -20037,6 +20037,9 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         public StartImportUploadedPartsRequest Request { get; set; } = null;
 
+        /// <summary>
+        /// When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
+        /// </summary>
         public bool? AutoCreateFolderPath { get; set; } = null;
 
         /// <summary>
@@ -20202,6 +20205,9 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         public int EntryId { get; set; }
 
+        /// <summary>
+        /// When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
+        /// </summary>
         public bool? AutoCreateFolderPath { get; set; } = null;
 
         /// <summary>
@@ -20363,6 +20369,9 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         public CreateEntryRequest Request { get; set; }
 
+        /// <summary>
+        /// When true, any missing folders in the request's `folderPath` are created; when false (default), a missing folder returns 404.
+        /// </summary>
         public bool? AutoCreateFolderPath { get; set; } = null;
 
         /// <summary>

--- a/src/Clients/RepositoryClients.cs
+++ b/src/Clients/RepositoryClients.cs
@@ -11412,6 +11412,7 @@ namespace Laserfiche.Repository.Api.Client
             var repositoryId = parameters.RepositoryId;
             var entryId = parameters.EntryId;
             var request = parameters.Request;
+            var autoCreateFolderPath = parameters.AutoCreateFolderPath;
             var culture = parameters.Culture;
 
             if (repositoryId == null)
@@ -11428,6 +11429,10 @@ namespace Laserfiche.Repository.Api.Client
                     urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(entryId, CultureInfo.InvariantCulture)));
                     urlBuilder_.Append("/Folder/ImportUploadedParts");
                     urlBuilder_.Append('?');
+                    if (autoCreateFolderPath != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("autoCreateFolderPath")).Append('=').Append(Uri.EscapeDataString(ConvertToString(autoCreateFolderPath, CultureInfo.InvariantCulture))).Append('&');
+                    }
                     if (culture != null)
                     {
                         urlBuilder_.Append(Uri.EscapeDataString("culture")).Append('=').Append(Uri.EscapeDataString(ConvertToString(culture, CultureInfo.InvariantCulture))).Append('&');
@@ -12553,6 +12558,7 @@ namespace Laserfiche.Repository.Api.Client
 
             var repositoryId = parameters.RepositoryId;
             var entryId = parameters.EntryId;
+            var autoCreateFolderPath = parameters.AutoCreateFolderPath;
             var culture = parameters.Culture;
             var file = parameters.File;
             var request = parameters.Request;
@@ -12572,6 +12578,10 @@ namespace Laserfiche.Repository.Api.Client
                     urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(entryId, CultureInfo.InvariantCulture)));
                     urlBuilder_.Append("/Folder/Import");
                     urlBuilder_.Append('?');
+                    if (autoCreateFolderPath != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("autoCreateFolderPath")).Append('=').Append(Uri.EscapeDataString(ConvertToString(autoCreateFolderPath, CultureInfo.InvariantCulture))).Append('&');
+                    }
                     if (culture != null)
                     {
                         urlBuilder_.Append(Uri.EscapeDataString("culture")).Append('=').Append(Uri.EscapeDataString(ConvertToString(culture, CultureInfo.InvariantCulture))).Append('&');
@@ -13434,6 +13444,7 @@ namespace Laserfiche.Repository.Api.Client
             var repositoryId = parameters.RepositoryId;
             var entryId = parameters.EntryId;
             var request = parameters.Request;
+            var autoCreateFolderPath = parameters.AutoCreateFolderPath;
             var culture = parameters.Culture;
 
             if (repositoryId == null)
@@ -13453,6 +13464,10 @@ namespace Laserfiche.Repository.Api.Client
                     urlBuilder_.Append(Uri.EscapeDataString(ConvertToString(entryId, CultureInfo.InvariantCulture)));
                     urlBuilder_.Append("/Folder/Children");
                     urlBuilder_.Append('?');
+                    if (autoCreateFolderPath != null)
+                    {
+                        urlBuilder_.Append(Uri.EscapeDataString("autoCreateFolderPath")).Append('=').Append(Uri.EscapeDataString(ConvertToString(autoCreateFolderPath, CultureInfo.InvariantCulture))).Append('&');
+                    }
                     if (culture != null)
                     {
                         urlBuilder_.Append(Uri.EscapeDataString("culture")).Append('=').Append(Uri.EscapeDataString(ConvertToString(culture, CultureInfo.InvariantCulture))).Append('&');
@@ -20022,6 +20037,8 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         public StartImportUploadedPartsRequest Request { get; set; } = null;
 
+        public bool? AutoCreateFolderPath { get; set; } = null;
+
         /// <summary>
         /// An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
         /// </summary>
@@ -20185,6 +20202,8 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         public int EntryId { get; set; }
 
+        public bool? AutoCreateFolderPath { get; set; } = null;
+
         /// <summary>
         /// An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag. This may be used when setting field values with tokens.
         /// </summary>
@@ -20343,6 +20362,8 @@ namespace Laserfiche.Repository.Api.Client
         /// The request body.
         /// </summary>
         public CreateEntryRequest Request { get; set; }
+
+        public bool? AutoCreateFolderPath { get; set; } = null;
 
         /// <summary>
         /// An optional query parameter used to indicate the locale that should be used. The value should be a standard language tag.
@@ -36839,6 +36860,15 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("volumeName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string VolumeName { get; set; }
 
+        /// <summary>
+        /// An optional folder path, relative to the entry given in the route, that the document is imported into.<br/>
+        /// Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the<br/>
+        /// `autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request<br/>
+        /// fails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior).
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("folderPath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string FolderPath { get; set; }
+
     }
 
     /// <summary>
@@ -37712,6 +37742,15 @@ namespace Laserfiche.Repository.Api.Client
         [Newtonsoft.Json.JsonProperty("generateImagePagesText", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool GenerateImagePagesText { get; set; } = true;
 
+        /// <summary>
+        /// An optional folder path, relative to the entry given in the route, that the document is imported into.<br/>
+        /// Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the<br/>
+        /// `autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request<br/>
+        /// fails with 404. When omitted, the document is imported directly into the route entry (unchanged behavior).
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("folderPath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string FolderPath { get; set; }
+
     }
 
     /// <summary>
@@ -38202,6 +38241,15 @@ namespace Laserfiche.Repository.Api.Client
         /// </summary>
         [Newtonsoft.Json.JsonProperty("volumeName", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string VolumeName { get; set; }
+
+        /// <summary>
+        /// An optional folder path, relative to the entry given in the route, that the new entry is created under.<br/>
+        /// Both `/` and `\` are accepted as separators. When any folder in this path does not exist, set the<br/>
+        /// `autoCreateFolderPath` query parameter to true to create the missing folders; otherwise the request<br/>
+        /// fails with 404. When omitted, the entry is created directly under the route entry (unchanged behavior).
+        /// </summary>
+        [Newtonsoft.Json.JsonProperty("folderPath", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string FolderPath { get; set; }
 
     }
 


### PR DESCRIPTION
Regenerates the V2 client for the recursive folder-path ("mkdir -p") surface shipped by the server (site-api-repository PR #176081, merged to main): the optional `folderPath` request-body property and the `autoCreateFolderPath` query flag on `ImportEntry`, `StartImportUploadedParts`, and `CreateEntry`. Purely additive — no changes to existing signatures.

Includes the `autoCreateFolderPath` query-parameter descriptions (server-side `<param>` docs added during review).

Regen only, per the standard release flow — the version bump and consolidated GA publish are handled by the separate release PR. No new client-lib integration tests: the server REST suite drives the identical generated client, so per-endpoint coverage there is authoritative (see site-api-repository/docs/analysis-dotnet-integration-test-overlap.md); this PR also carries the matching regen-dotnet-client skill note.