### PR TITLE
Release 2.4.0: bump VERSION_PREFIX and changelog for folder-path auto…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   API_VERSION: 'v2'
-  VERSION_PREFIX: '2.3.0'
+  VERSION_PREFIX: '2.4.0'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.4.0
+
+### Features
+
+- Add optional `FolderPath` request property and `AutoCreateFolderPath` query parameter to `ImportEntryAsync`, `StartImportUploadedPartsAsync`, and `CreateEntryAsync`. When `AutoCreateFolderPath` is `true`, any missing folders in `FolderPath` are created; when `false` (default), a missing folder returns 404.
+
 ## 2.3.0
 
 ### Features


### PR DESCRIPTION
…-create

Bumps VERSION_PREFIX to 2.4.0 for the FolderPath/AutoCreateFolderPath support on ImportEntryAsync, StartImportUploadedPartsAsync, and CreateEntryAsync (Epic #687490).